### PR TITLE
Make URI fields optional and streamline accounts UI

### DIFF
--- a/API/Fuse.Core/Commands/ApplicationCommands.cs
+++ b/API/Fuse.Core/Commands/ApplicationCommands.cs
@@ -35,7 +35,7 @@ public record CreateApplicationInstance(
     Guid ApplicationId,
     Guid EnvironmentId,
     Guid? ServerId,
-    Uri BaseUri,
+    Uri? BaseUri,
     Uri? HealthUri,
     Uri? OpenApiUri,
     string? Version,
@@ -47,7 +47,7 @@ public record UpdateApplicationInstance(
     Guid InstanceId,
     Guid EnvironmentId,
     Guid? ServerId,
-    Uri BaseUri,
+    Uri? BaseUri,
     Uri? HealthUri,
     Uri? OpenApiUri,
     string? Version,
@@ -63,14 +63,14 @@ public record DeleteApplicationInstance(
 public record CreateApplicationPipeline(
     Guid ApplicationId,
     string Name,
-    Uri PipelineUri
+    Uri? PipelineUri
 );
 
 public record UpdateApplicationPipeline(
     Guid ApplicationId,
     Guid PipelineId,
     string Name,
-    Uri PipelineUri
+    Uri? PipelineUri
 );
 
 public record DeleteApplicationPipeline(

--- a/API/Fuse.Core/Commands/DataStoreCommands.cs
+++ b/API/Fuse.Core/Commands/DataStoreCommands.cs
@@ -7,7 +7,7 @@ public record CreateDataStore(
     string Kind,
     Guid EnvironmentId,
     Guid? ServerId,
-    Uri ConnectionUri,
+    Uri? ConnectionUri,
     HashSet<Guid> TagIds
 );
 
@@ -17,7 +17,7 @@ public record UpdateDataStore(
     string Kind,
     Guid EnvironmentId,
     Guid? ServerId,
-    Uri ConnectionUri,
+    Uri? ConnectionUri,
     HashSet<Guid> TagIds
 );
 

--- a/API/Fuse.Core/Commands/ExternalResourceCommands.cs
+++ b/API/Fuse.Core/Commands/ExternalResourceCommands.cs
@@ -5,7 +5,7 @@ namespace Fuse.Core.Commands;
 public record CreateExternalResource(
     string Name,
     string? Description,
-    Uri ResourceUri,
+    Uri? ResourceUri,
     HashSet<Guid> TagIds
 );
 
@@ -13,7 +13,7 @@ public record UpdateExternalResource(
     Guid Id,
     string Name,
     string? Description,
-    Uri ResourceUri,
+    Uri? ResourceUri,
     HashSet<Guid> TagIds
 );
 

--- a/API/Fuse.Core/Models/Application.cs
+++ b/API/Fuse.Core/Models/Application.cs
@@ -21,7 +21,7 @@ public record ApplicationPipeline
 (
     Guid Id,
     string Name,
-    Uri PipelineUri
+    Uri? PipelineUri
 );
 
 public record ApplicationInstance
@@ -29,7 +29,7 @@ public record ApplicationInstance
     Guid Id,
     Guid EnvironmentId,
     Guid? ServerId,
-    Uri BaseUri,
+    Uri? BaseUri,
     Uri? HealthUri,
     Uri? OpenApiUri,
     string? Version,

--- a/API/Fuse.Core/Models/DataStore.cs
+++ b/API/Fuse.Core/Models/DataStore.cs
@@ -8,7 +8,7 @@ public record DataStore
     string Kind,
     Guid EnvironmentId,
     Guid? ServerId,
-    Uri ConnectionUri,
+    Uri? ConnectionUri,
     HashSet<Guid> TagIds,
     DateTime CreatedAt,
     DateTime UpdatedAt

--- a/API/Fuse.Core/Models/ExternalResource.cs
+++ b/API/Fuse.Core/Models/ExternalResource.cs
@@ -5,7 +5,7 @@ public record ExternalResource
     Guid Id,
     string Name,
     string? Description,
-    Uri ResourceUri,
+    Uri? ResourceUri,
     HashSet<Guid> TagIds,
     DateTime CreatedAt,
     DateTime UpdatedAt

--- a/API/Fuse.Tests/Services/DataStoreServiceTests.cs
+++ b/API/Fuse.Tests/Services/DataStoreServiceTests.cs
@@ -109,6 +109,17 @@ public class DataStoreServiceTests
     }
 
     [Fact]
+    public async Task CreateDataStore_AllowsMissingConnectionUri()
+    {
+        var env = new EnvironmentInfo(Guid.NewGuid(), "E", null, new HashSet<Guid>());
+        var store = NewStore(envs: new[] { env });
+        var service = new DataStoreService(store, new TagLookupService(store));
+        var result = await service.CreateDataStoreAsync(new CreateDataStore("D1", "sql", env.Id, null, null, new HashSet<Guid>()));
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ConnectionUri.Should().BeNull();
+    }
+
+    [Fact]
     public async Task UpdateDataStore_NotFound()
     {
         var env = new EnvironmentInfo(Guid.NewGuid(), "E", null, new HashSet<Guid>());
@@ -159,6 +170,18 @@ public class DataStoreServiceTests
         got!.Name.Should().Be("New");
         got.Kind.Should().Be("nosql");
         got.ConnectionUri.Should().Be(new Uri("http://new"));
+    }
+
+    [Fact]
+    public async Task UpdateDataStore_AllowsClearingConnectionUri()
+    {
+        var env = new EnvironmentInfo(Guid.NewGuid(), "E", null, new HashSet<Guid>());
+        var ds = new DataStore(Guid.NewGuid(), "HasUri", null, "sql", env.Id, null, new Uri("http://old"), new HashSet<Guid>(), DateTime.UtcNow, DateTime.UtcNow);
+        var store = NewStore(envs: new[] { env }, ds: new[] { ds });
+        var service = new DataStoreService(store, new TagLookupService(store));
+        var result = await service.UpdateDataStoreAsync(new UpdateDataStore(ds.Id, "HasUri", "sql", env.Id, null, null, new HashSet<Guid>()));
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ConnectionUri.Should().BeNull();
     }
 
     [Fact]

--- a/API/Fuse.Tests/Services/ExternalResourceServiceTests.cs
+++ b/API/Fuse.Tests/Services/ExternalResourceServiceTests.cs
@@ -60,6 +60,16 @@ public class ExternalResourceServiceTests
     }
 
     [Fact]
+    public async Task CreateExternalResource_AllowsMissingUri()
+    {
+        var store = NewStore();
+        var service = new ExternalResourceService(store, new TagLookupService(store));
+        var result = await service.CreateExternalResourceAsync(new CreateExternalResource("Res", null, null, new HashSet<Guid>()));
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ResourceUri.Should().BeNull();
+    }
+
+    [Fact]
     public async Task CreateExternalResource_EmptyName_ReturnsValidation()
     {
         var store = NewStore();
@@ -113,6 +123,17 @@ public class ExternalResourceServiceTests
         got!.Name.Should().Be("New");
         got.Description.Should().Be("d");
         got.ResourceUri.Should().Be(new Uri("http://new"));
+    }
+
+    [Fact]
+    public async Task UpdateExternalResource_AllowsClearingUri()
+    {
+        var existing = new ExternalResource(Guid.NewGuid(), "Res", null, new Uri("http://x"), new HashSet<Guid>(), DateTime.UtcNow, DateTime.UtcNow);
+        var store = NewStore(res: new[] { existing });
+        var service = new ExternalResourceService(store, new TagLookupService(store));
+        var result = await service.UpdateExternalResourceAsync(new UpdateExternalResource(existing.Id, "Res", null, null, new HashSet<Guid>()));
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ResourceUri.Should().BeNull();
     }
 
     [Fact]

--- a/UI/Fuse.Web/src/components/accounts/AccountForm.vue
+++ b/UI/Fuse.Web/src/components/accounts/AccountForm.vue
@@ -1,0 +1,117 @@
+<template>
+  <div class="form-grid">
+    <q-select
+      v-model="form.targetKind"
+      label="Target Kind"
+      dense
+      outlined
+      emit-value
+      map-options
+      :options="targetKindOptions"
+    />
+    <q-select
+      v-model="form.targetId"
+      label="Target"
+      dense
+      outlined
+      emit-value
+      map-options
+      :options="targetOptions"
+    />
+    <q-select
+      v-model="form.authKind"
+      label="Auth Kind"
+      dense
+      outlined
+      emit-value
+      map-options
+      :options="authKindOptions"
+    />
+    <q-input v-model="form.userName" label="Username" dense outlined />
+    <q-input v-model="form.secretRef" label="Secret Reference" dense outlined />
+    <q-select
+      v-model="form.tagIds"
+      label="Tags"
+      dense
+      outlined
+      use-chips
+      multiple
+      emit-value
+      map-options
+      :options="tagOptions"
+    />
+  </div>
+
+  <div class="parameters-section">
+    <div class="section-header q-mt-md">
+      <div class="text-subtitle1">Parameters</div>
+      <q-btn dense flat icon="add" label="Add" @click="addParameter" />
+    </div>
+    <div v-if="form.parameters.length" class="parameter-grid">
+      <div v-for="(pair, index) in form.parameters" :key="index" class="parameter-row">
+        <q-input v-model="pair.key" label="Key" dense outlined />
+        <q-input v-model="pair.value" label="Value" dense outlined />
+        <q-btn flat dense round icon="delete" color="negative" @click="removeParameter(index)" />
+      </div>
+    </div>
+    <div v-else class="text-grey">No parameters.</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { toRefs } from 'vue'
+import type { AccountFormModel, TargetOption, SelectOption } from './types'
+import type { AuthKind, TargetKind } from '../../api/client'
+
+const form = defineModel<AccountFormModel>({ required: true })
+
+const props = defineProps<{
+  targetKindOptions: SelectOption<TargetKind>[]
+  targetOptions: TargetOption[]
+  authKindOptions: SelectOption<AuthKind>[]
+  tagOptions: TargetOption[]
+}>()
+
+const { targetKindOptions, targetOptions, authKindOptions, tagOptions } = toRefs(props)
+
+function addParameter() {
+  form.value.parameters.push({ key: '', value: '' })
+}
+
+function removeParameter(index: number) {
+  form.value.parameters.splice(index, 1)
+}
+</script>
+
+<style scoped>
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.parameters-section {
+  margin-top: 1.5rem;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.parameter-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.parameter-row {
+  display: contents;
+}
+
+.parameter-row > *:nth-child(3) {
+  align-self: center;
+}
+</style>

--- a/UI/Fuse.Web/src/components/accounts/AccountsTable.vue
+++ b/UI/Fuse.Web/src/components/accounts/AccountsTable.vue
@@ -1,0 +1,95 @@
+<template>
+  <q-card class="content-card">
+    <q-table
+      flat
+      bordered
+      :rows="rows"
+      :columns="columns"
+      row-key="id"
+      :loading="loading"
+      :pagination="pagination"
+    >
+      <template #body-cell-target="props">
+        <q-td :props="props">
+          {{ targetResolver(props.row) }}
+        </q-td>
+      </template>
+      <template #body-cell-tags="props">
+        <q-td :props="props">
+          <div v-if="props.row.tagIds?.length" class="tag-list">
+            <q-badge
+              v-for="tagId in props.row.tagIds"
+              :key="tagId"
+              outline
+              color="primary"
+              :label="tagLookup[tagId] ?? tagId"
+            />
+          </div>
+          <span v-else class="text-grey">—</span>
+        </q-td>
+      </template>
+      <template #body-cell-grants="props">
+        <q-td :props="props">
+          <q-badge color="secondary" :label="`${props.row.grants?.length ?? 0} grants`" />
+        </q-td>
+      </template>
+      <template #body-cell-actions="props">
+        <q-td :props="props" class="text-right">
+          <q-btn flat dense round icon="edit" color="primary" @click="emit('edit', props.row)" />
+          <q-btn
+            flat
+            dense
+            round
+            icon="delete"
+            color="negative"
+            class="q-ml-xs"
+            @click="emit('delete', props.row)"
+          />
+        </q-td>
+      </template>
+      <template #no-data>
+        <div class="q-pa-md text-grey-7">No accounts configured.</div>
+      </template>
+    </q-table>
+  </q-card>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { QTableColumn } from 'quasar'
+import type { Account } from '../../api/client'
+
+interface Props {
+  accounts: Account[]
+  loading: boolean
+  pagination: { rowsPerPage: number }
+  tagLookup: Record<string, string | undefined>
+  targetResolver: (account: Account) => string
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{ (event: 'edit', account: Account): void; (event: 'delete', account: Account): void }>()
+
+const rows = computed(() => props.accounts ?? [])
+
+const columns: QTableColumn<Account>[] = [
+  { name: 'target', label: 'Target', field: 'targetId', align: 'left', sortable: true },
+  { name: 'authKind', label: 'Auth Kind', field: 'authKind', align: 'left' },
+  { name: 'userName', label: 'Username', field: 'userName', align: 'left' },
+  { name: 'grants', label: 'Grants', field: 'grants', align: 'left' },
+  { name: 'tags', label: 'Tags', field: 'tagIds', align: 'left' },
+  { name: 'actions', label: '', field: (row) => row.id, align: 'right' }
+]
+</script>
+
+<style scoped>
+.content-card {
+  flex: 1;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+</style>

--- a/UI/Fuse.Web/src/components/accounts/types.ts
+++ b/UI/Fuse.Web/src/components/accounts/types.ts
@@ -1,0 +1,23 @@
+import type { AuthKind, TargetKind } from '../../api/client'
+
+export interface KeyValuePair {
+  key: string
+  value: string
+}
+
+export interface AccountFormModel {
+  targetKind: TargetKind
+  targetId: string | null
+  authKind: AuthKind
+  userName: string
+  secretRef: string
+  parameters: KeyValuePair[]
+  tagIds: string[]
+}
+
+export interface SelectOption<T = string> {
+  label: string
+  value: T
+}
+
+export type TargetOption = SelectOption<string>

--- a/UI/Fuse.Web/src/utils/error.ts
+++ b/UI/Fuse.Web/src/utils/error.ts
@@ -1,18 +1,91 @@
+import { ApiException } from '../api/client'
+
+type ProblemDetails = {
+  error?: string
+  errors?: Record<string, string[] | string>
+  message?: string
+  title?: string
+  detail?: string
+}
+
+function fromProblemDetails(details: ProblemDetails | undefined): string | undefined {
+  if (!details) {
+    return undefined
+  }
+
+  if (details.error && details.error.trim().length) {
+    return details.error
+  }
+
+  if (details.detail && details.detail.trim().length) {
+    return details.detail
+  }
+
+  if (details.title && details.title.trim().length) {
+    return details.title
+  }
+
+  if (details.message && details.message.trim().length) {
+    return details.message
+  }
+
+  if (details.errors) {
+    for (const value of Object.values(details.errors)) {
+      if (Array.isArray(value) && value.length) {
+        const candidate = value.find((item) => !!item?.trim?.())
+        if (candidate) {
+          return candidate
+        }
+      } else if (typeof value === 'string' && value.trim().length) {
+        return value
+      }
+    }
+  }
+
+  return undefined
+}
+
+function parseResponsePayload(payload: string | undefined): ProblemDetails | undefined {
+  if (!payload) {
+    return undefined
+  }
+
+  try {
+    const parsed = JSON.parse(payload)
+    if (parsed && typeof parsed === 'object') {
+      return parsed as ProblemDetails
+    }
+  } catch (err) {
+    // ignore JSON parse errors
+  }
+
+  return undefined
+}
+
 export function getErrorMessage(error: unknown, fallback = 'Request failed'): string {
   if (typeof error === 'string') {
     return error
   }
 
+  if (error instanceof ApiException) {
+    const parsed = parseResponsePayload(error.response)
+    const message = fromProblemDetails(parsed)
+    if (message) {
+      return message
+    }
+    if (error.message?.trim().length) {
+      return error.message
+    }
+  }
+
   if (error && typeof error === 'object') {
-    const maybeError = error as { message?: string; title?: string; detail?: string }
-    if (maybeError.detail) {
-      return maybeError.detail
+    const maybeProblem = fromProblemDetails(error as ProblemDetails)
+    if (maybeProblem) {
+      return maybeProblem
     }
-    if (maybeError.title) {
-      return maybeError.title
-    }
-    if (maybeError.message) {
-      return maybeError.message
+
+    if (error instanceof Error && error.message.trim().length) {
+      return error.message
     }
   }
 


### PR DESCRIPTION
## Summary
- allow URI fields across application, data store, and external resource commands/models to be nullable and cover the change with service tests
- improve API error parsing in the web client to surface validation messages, and refactor the accounts page into reusable table/form components
- add reusable account form and table components to simplify AccountsPage markup and state management

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690bc6f7dd7c8333879ed05e64e034f6