### PR TITLE
Add UI support for account grants and instance dependencies

### DIFF
--- a/UI/Fuse.Web/src/components/accounts/AccountGrantsSection.vue
+++ b/UI/Fuse.Web/src/components/accounts/AccountGrantsSection.vue
@@ -1,0 +1,134 @@
+<template>
+  <q-expansion-item dense expand-icon="expand_more" icon="security" label="Grants" class="q-mt-lg">
+    <template #default>
+      <div class="section-header">
+        <div>
+          <div class="text-subtitle1">Account Grants</div>
+          <div class="text-caption text-grey-7">Document permissions granted to this account.</div>
+        </div>
+        <q-btn
+          color="primary"
+          label="Add Grant"
+          dense
+          icon="add"
+          :disable="disableActions"
+          @click="emit('add')"
+        />
+      </div>
+      <q-table
+        flat
+        bordered
+        dense
+        :rows="rows"
+        :columns="columns"
+        row-key="__key"
+        class="q-mt-md"
+      >
+        <template #body-cell-privileges="props">
+          <q-td :props="props">
+            <div v-if="props.row.privileges?.length" class="tag-list">
+              <q-badge
+                v-for="privilege in props.row.privileges"
+                :key="privilege"
+                outline
+                color="secondary"
+                :label="privilege"
+              />
+            </div>
+            <span v-else class="text-grey">—</span>
+          </q-td>
+        </template>
+        <template #body-cell-actions="props">
+          <q-td :props="props" class="text-right">
+            <q-btn
+              dense
+              flat
+              round
+              icon="edit"
+              color="primary"
+              :disable="disableActions"
+              @click="emit('edit', { grant: props.row.__source, index: props.row.__index })"
+            />
+            <q-btn
+              dense
+              flat
+              round
+              icon="delete"
+              color="negative"
+              class="q-ml-xs"
+              :disable="disableActions"
+              @click="emit('delete', { grant: props.row.__source, index: props.row.__index })"
+            />
+          </q-td>
+        </template>
+        <template #no-data>
+          <div class="q-pa-sm text-grey-7">No grants defined.</div>
+        </template>
+      </q-table>
+    </template>
+  </q-expansion-item>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { QTableColumn } from 'quasar'
+import type { Grant, Privilege } from '../../api/client'
+
+interface GrantRow {
+  __key: string
+  __index: number
+  __source: Grant
+  id?: string
+  database?: string
+  schema?: string
+  privileges?: Privilege[]
+}
+
+const props = withDefaults(
+  defineProps<{
+    grants: readonly Grant[]
+    disableActions?: boolean
+  }>(),
+  {
+    grants: () => [],
+    disableActions: false
+  }
+)
+
+const emit = defineEmits<{
+  (e: 'add'): void
+  (e: 'edit', payload: { grant: Grant; index: number }): void
+  (e: 'delete', payload: { grant: Grant; index: number }): void
+}>()
+
+const columns: QTableColumn<GrantRow>[] = [
+  { name: 'database', label: 'Database', field: 'database', align: 'left' },
+  { name: 'schema', label: 'Schema', field: 'schema', align: 'left' },
+  { name: 'privileges', label: 'Privileges', field: 'privileges', align: 'left' },
+  { name: 'actions', label: '', field: (row) => row.id, align: 'right' }
+]
+
+const rows = computed<GrantRow[]>(() =>
+  props.grants.map((grant, index) => ({
+    ...grant,
+    __key: grant.id ?? `grant-${index}`,
+    __index: index,
+    __source: grant
+  }))
+)
+</script>
+
+<style scoped>
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+</style>

--- a/UI/Fuse.Web/src/components/accounts/types.ts
+++ b/UI/Fuse.Web/src/components/accounts/types.ts
@@ -1,4 +1,4 @@
-import type { AuthKind, TargetKind } from '../../api/client'
+import type { AuthKind, Grant, TargetKind } from '../../api/client'
 
 export interface KeyValuePair {
   key: string
@@ -13,6 +13,7 @@ export interface AccountFormModel {
   secretRef: string
   parameters: KeyValuePair[]
   tagIds: string[]
+  grants: Grant[]
 }
 
 export interface SelectOption<T = string> {

--- a/UI/Fuse.Web/src/components/applications/InstanceDependenciesSection.vue
+++ b/UI/Fuse.Web/src/components/applications/InstanceDependenciesSection.vue
@@ -1,0 +1,122 @@
+<template>
+  <q-expansion-item dense expand-icon="expand_more" icon="link" label="Dependencies" class="q-mt-md">
+    <template #default>
+      <div class="section-header">
+        <div>
+          <div class="text-subtitle1">Service Dependencies</div>
+          <div class="text-caption text-grey-7">
+            Describe downstream systems this instance relies on.
+          </div>
+        </div>
+        <q-btn
+          color="primary"
+          label="Add Dependency"
+          dense
+          icon="add"
+          :disable="disableActions"
+          @click="emit('add')"
+        />
+      </div>
+      <q-table flat bordered dense :rows="rows" :columns="columns" row-key="__key" class="q-mt-md">
+        <template #body-cell-target="props">
+          <q-td :props="props">
+            {{ resolveTargetName(props.row.__source) }}
+          </q-td>
+        </template>
+        <template #body-cell-account="props">
+          <q-td :props="props">
+            {{ resolveAccountName(props.row.accountId) }}
+          </q-td>
+        </template>
+        <template #body-cell-actions="props">
+          <q-td :props="props" class="text-right">
+            <q-btn
+              dense
+              flat
+              round
+              icon="edit"
+              color="primary"
+              :disable="disableActions"
+              @click="emit('edit', { dependency: props.row.__source, index: props.row.__index })"
+            />
+            <q-btn
+              dense
+              flat
+              round
+              icon="delete"
+              color="negative"
+              class="q-ml-xs"
+              :disable="disableActions"
+              @click="emit('delete', { dependency: props.row.__source, index: props.row.__index })"
+            />
+          </q-td>
+        </template>
+        <template #no-data>
+          <div class="q-pa-sm text-grey-7">No dependencies documented.</div>
+        </template>
+      </q-table>
+    </template>
+  </q-expansion-item>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { QTableColumn } from 'quasar'
+import type { ApplicationInstanceDependency, TargetKind } from '../../api/client'
+
+interface DependencyRow {
+  __key: string
+  __index: number
+  __source: ApplicationInstanceDependency
+  id?: string
+  targetId?: string
+  targetKind?: TargetKind
+  port?: number
+  accountId?: string
+}
+
+const props = withDefaults(
+  defineProps<{
+    dependencies: readonly ApplicationInstanceDependency[]
+    disableActions?: boolean
+    resolveTargetName: (dependency: ApplicationInstanceDependency) => string
+    resolveAccountName: (accountId?: string | null) => string
+  }>(),
+  {
+    dependencies: () => [],
+    disableActions: false
+  }
+)
+
+const emit = defineEmits<{
+  (e: 'add'): void
+  (e: 'edit', payload: { dependency: ApplicationInstanceDependency; index: number }): void
+  (e: 'delete', payload: { dependency: ApplicationInstanceDependency; index: number }): void
+}>()
+
+const columns: QTableColumn<DependencyRow>[] = [
+  { name: 'target', label: 'Target', field: 'targetId', align: 'left' },
+  { name: 'targetKind', label: 'Kind', field: 'targetKind', align: 'left' },
+  { name: 'port', label: 'Port', field: 'port', align: 'left' },
+  { name: 'account', label: 'Account', field: 'accountId', align: 'left' },
+  { name: 'actions', label: '', field: (row) => row.id, align: 'right' }
+]
+
+const rows = computed<DependencyRow[]>(() =>
+  props.dependencies.map((dependency, index) => ({
+    ...dependency,
+    __key: dependency.id ?? `dependency-${index}`,
+    __index: index,
+    __source: dependency
+  }))
+)
+</script>
+
+<style scoped>
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- add a reusable account grants section component and surface it in the account create and edit dialogs
- preserve grant data when updating accounts and allow pre-account grant collection during creation
- enable managing application instance dependencies with a dedicated section, dialog, and supporting API interactions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690c54520c988333889b35f7974adfbe