### PR TITLE
Add onboarding tour driver integration

### DIFF
--- a/UI/Fuse.Web/package-lock.json
+++ b/UI/Fuse.Web/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/vue-query": "^5.90.7",
         "@vueuse/core": "^14.0.0",
         "axios": "^1.13.2",
+        "driver.js": "^1.3.6",
         "pinia": "^3.0.4",
         "quasar": "^2.18.5",
         "vue": "^3.5.22",
@@ -1666,6 +1667,12 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/driver.js": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.3.6.tgz",
+      "integrity": "sha512-g2nNuu+tWmPpuoyk3ffpT9vKhjPz4NrJzq6mkRDZIwXCrFhrKdDJ9TX5tJOBpvCTBrBYjgRQ17XlcQB15q4gMg==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/UI/Fuse.Web/package.json
+++ b/UI/Fuse.Web/package.json
@@ -13,6 +13,7 @@
     "@tanstack/vue-query": "^5.90.7",
     "@vueuse/core": "^14.0.0",
     "axios": "^1.13.2",
+    "driver.js": "^1.3.6",
     "pinia": "^3.0.4",
     "quasar": "^2.18.5",
     "vue": "^3.5.22",

--- a/UI/Fuse.Web/src/composables/useOnboardingTour.ts
+++ b/UI/Fuse.Web/src/composables/useOnboardingTour.ts
@@ -1,0 +1,239 @@
+import { driver as createDriver, type Driver, type DriveStep, type Popover } from 'driver.js'
+import type { Router } from 'vue-router'
+import { useRouter } from 'vue-router'
+
+import { waitForElement } from '../utils/dom'
+import { useEnvironments } from './useEnvironments'
+import { useDataStores } from './useDataStores'
+import { useApplications } from './useApplications'
+import { useOnboardingStore } from '../stores/onboarding'
+
+interface OnboardingStep {
+  id: string
+  route: string
+  selector: string
+  popover: Popover
+}
+
+let driverInstance: Driver | null = null
+let activeSteps: OnboardingStep[] = []
+let currentStepIndex = -1
+let isNavigating = false
+let routerRef: Router | null = null
+let onboardingStoreRef: ReturnType<typeof useOnboardingStore> | null = null
+
+function resetTourState() {
+  activeSteps = []
+  currentStepIndex = -1
+  isNavigating = false
+}
+
+async function navigateToStep(index: number, initial = false): Promise<void> {
+  if (!driverInstance || !routerRef) {
+    return
+  }
+
+  if (index < 0) {
+    return
+  }
+
+  if (index >= activeSteps.length) {
+    driverInstance.destroy()
+    return
+  }
+
+  if (isNavigating) {
+    return
+  }
+
+  const step = activeSteps[index]
+
+  if (!step) {
+    driverInstance.destroy()
+    return
+  }
+  isNavigating = true
+
+  try {
+    if (routerRef.currentRoute.value.path !== step.route) {
+      await routerRef.push(step.route)
+    }
+
+    await waitForElement(step.selector)
+
+    if (initial || !driverInstance.isActive()) {
+      driverInstance.drive(index)
+    } else {
+      driverInstance.moveTo(index)
+    }
+
+    currentStepIndex = index
+  } catch (error) {
+    console.error('Failed to navigate to onboarding tour step.', error)
+    driverInstance.destroy()
+  } finally {
+    isNavigating = false
+  }
+}
+
+function ensureDriver(): Driver {
+  if (!driverInstance) {
+    driverInstance = createDriver({
+      animate: true,
+      smoothScroll: true,
+      allowClose: true,
+      showProgress: true,
+      onNextClick: () => {
+        void navigateToStep(currentStepIndex + 1)
+      },
+      onPrevClick: () => {
+        void navigateToStep(currentStepIndex - 1)
+      },
+      onDestroyed: () => {
+        onboardingStoreRef?.endTour()
+        resetTourState()
+      }
+    })
+  } else {
+    driverInstance.setConfig({
+      animate: true,
+      smoothScroll: true,
+      allowClose: true,
+      showProgress: true,
+      onNextClick: () => {
+        void navigateToStep(currentStepIndex + 1)
+      },
+      onPrevClick: () => {
+        void navigateToStep(currentStepIndex - 1)
+      },
+      onDestroyed: () => {
+        onboardingStoreRef?.endTour()
+        resetTourState()
+      }
+    })
+  }
+
+  return driverInstance
+}
+
+export function useOnboardingTour() {
+  const router = useRouter()
+  const onboardingStore = useOnboardingStore()
+  const environmentsQuery = useEnvironments()
+  const dataStoresQuery = useDataStores()
+  const applicationsQuery = useApplications()
+
+  routerRef = router
+
+  async function startTour(): Promise<void> {
+    onboardingStoreRef = onboardingStore
+    const driver = ensureDriver()
+
+    if (driver.isActive()) {
+      driver.destroy()
+    }
+
+    resetTourState()
+
+    await Promise.allSettled([
+      environmentsQuery.refetch(),
+      dataStoresQuery.refetch(),
+      applicationsQuery.refetch()
+    ])
+
+    const environments = environmentsQuery.data.value ?? []
+    const dataStores = dataStoresQuery.data.value ?? []
+    const applications = applicationsQuery.data.value ?? []
+
+    const firstApplication = applications.find((application) => application?.id)
+
+    const stepsToRun: OnboardingStep[] = []
+
+    if (environments.length === 0) {
+      stepsToRun.push({
+        id: 'environments',
+        route: '/environments',
+        selector: '[data-tour-id="environments"]',
+        popover: {
+          title: 'Add your first environment',
+          description: 'Environments describe the deployment targets for your applications.'
+        }
+      })
+    }
+
+    if (dataStores.length === 0) {
+      stepsToRun.push({
+        id: 'data-stores',
+        route: '/data-stores',
+        selector: '[data-tour-id="data-stores"]',
+        popover: {
+          title: 'Connect a data store',
+          description: 'Data stores link applications to the infrastructure and services they depend on.'
+        }
+      })
+    }
+
+    if (applications.length === 0) {
+      stepsToRun.push({
+        id: 'applications',
+        route: '/applications',
+        selector: '[data-tour-id="applications"]',
+        popover: {
+          title: 'Create your first application',
+          description: 'Applications track deployments, pipelines, and the environments they target.'
+        }
+      })
+    }
+
+    if (firstApplication?.id) {
+      stepsToRun.push({
+        id: 'application-detail',
+        route: `/applications/${encodeURIComponent(firstApplication.id)}`,
+        selector: '[data-tour-id="application-detail"]',
+        popover: {
+          title: 'Review application details',
+          description: 'Manage application instances, pipelines, and integrations from this view.'
+        }
+      })
+    }
+
+    const driverSteps: DriveStep[] = stepsToRun.map((step) => ({
+      element: step.selector,
+      popover: step.popover
+    }))
+
+    const hasSteps = driverSteps.length > 0
+
+    if (!hasSteps) {
+      driver.setSteps([])
+      onboardingStore.endTour()
+      resetTourState()
+      return
+    }
+
+    activeSteps = stepsToRun
+    driver.setSteps(driverSteps)
+    onboardingStore.startTour()
+
+    await navigateToStep(0, true)
+  }
+
+  function cancelTour() {
+    if (driverInstance?.isActive()) {
+      driverInstance.destroy()
+    } else {
+      onboardingStore.endTour()
+      resetTourState()
+    }
+  }
+
+  function markCompleted() {
+    onboardingStore.markTourCompleted()
+  }
+
+  return {
+    startTour,
+    cancelTour,
+    markCompleted
+  }
+}

--- a/UI/Fuse.Web/src/main.ts
+++ b/UI/Fuse.Web/src/main.ts
@@ -10,6 +10,7 @@ import '@quasar/extras/material-icons/material-icons.css'
 // Import Quasar css
 import 'quasar/dist/quasar.sass'
 import './styles/theme.scss'
+import 'driver.js/dist/driver.css'
 
 import App from './App.vue'
 

--- a/UI/Fuse.Web/src/stores/onboarding.ts
+++ b/UI/Fuse.Web/src/stores/onboarding.ts
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia'
+
+export const useOnboardingStore = defineStore('onboarding', {
+  state: () => ({
+    isTourActive: false,
+    isTourCompleted: false
+  }),
+  actions: {
+    startTour() {
+      this.isTourActive = true
+    },
+    endTour() {
+      this.isTourActive = false
+    },
+    markTourCompleted() {
+      this.isTourCompleted = true
+    }
+  }
+})

--- a/UI/Fuse.Web/src/utils/dom.ts
+++ b/UI/Fuse.Web/src/utils/dom.ts
@@ -1,0 +1,39 @@
+export function waitForElement<T extends Element = Element>(
+  selector: string,
+  timeout = 10000,
+  interval = 100
+): Promise<T> {
+  if (typeof document === 'undefined') {
+    return Promise.reject(new Error('waitForElement can only be used in a browser environment.'))
+  }
+
+  const existing = document.querySelector<T>(selector)
+  if (existing) {
+    return Promise.resolve(existing)
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const start = Date.now()
+
+    const intervalId = window.setInterval(() => {
+      const element = document.querySelector<T>(selector)
+      if (element) {
+        window.clearInterval(intervalId)
+        window.clearTimeout(timeoutId)
+        resolve(element)
+        return
+      }
+
+      if (Date.now() - start >= timeout) {
+        window.clearInterval(intervalId)
+        window.clearTimeout(timeoutId)
+        reject(new Error(`Element matching selector "${selector}" was not found within ${timeout}ms.`))
+      }
+    }, interval)
+
+    const timeoutId = window.setTimeout(() => {
+      window.clearInterval(intervalId)
+      reject(new Error(`Element matching selector "${selector}" was not found within ${timeout}ms.`))
+    }, timeout)
+  })
+}


### PR DESCRIPTION
## Summary
- add the driver.js dependency and load its styles with the Quasar entrypoint
- introduce a DOM helper and onboarding store to support guided tour logic
- build a useOnboardingTour composable that orchestrates driver.js steps and navigation based on existing data

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f56a7e1bc8333a22ef1f7e2f3eea4)