### PR TITLE
Enhance onboarding tour targets and cheat sheet experience

### DIFF
--- a/UI/Fuse.Web/src/App.vue
+++ b/UI/Fuse.Web/src/App.vue
@@ -82,6 +82,7 @@
             v-ripple
             :to="{ name: 'home' }"
             exact-active-class="bg-primary text-white"
+            data-tour-id="nav-home"
           >
             <q-item-section avatar>
               <q-icon name="home" />
@@ -98,6 +99,7 @@
             v-ripple
             :to="{ name: 'applications' }"
             active-class="bg-primary text-white"
+            data-tour-id="nav-applications"
           >
             <q-item-section avatar>
               <q-icon name="apps" />
@@ -112,6 +114,7 @@
             v-ripple
             :to="{ name: 'accounts' }"
             active-class="bg-primary text-white"
+            data-tour-id="nav-accounts"
           >
             <q-item-section avatar>
               <q-icon name="vpn_key" />
@@ -126,6 +129,7 @@
             v-ripple
             :to="{ name: 'dataStores' }"
             active-class="bg-primary text-white"
+            data-tour-id="nav-data-stores"
           >
             <q-item-section avatar>
               <q-icon name="storage" />
@@ -140,6 +144,7 @@
             v-ripple
             :to="{ name: 'servers' }"
             active-class="bg-primary text-white"
+            data-tour-id="nav-servers"
           >
             <q-item-section avatar>
               <q-icon name="dns" />
@@ -154,6 +159,7 @@
             v-ripple
             :to="{ name: 'environments' }"
             active-class="bg-primary text-white"
+            data-tour-id="nav-environments"
           >
             <q-item-section avatar>
               <q-icon name="cloud" />
@@ -168,6 +174,7 @@
             v-ripple
             :to="{ name: 'externalResources' }"
             active-class="bg-primary text-white"
+            data-tour-id="nav-external-resources"
           >
             <q-item-section avatar>
               <q-icon name="link" />
@@ -182,6 +189,7 @@
             v-ripple
             :to="{ name: 'tags' }"
             active-class="bg-primary text-white"
+            data-tour-id="nav-tags"
           >
             <q-item-section avatar>
               <q-icon name="label" />
@@ -196,6 +204,7 @@
             v-ripple
             :to="{ name: 'security' }"
             active-class="bg-primary text-white"
+            data-tour-id="nav-security"
           >
             <q-item-section avatar>
               <q-icon name="security" />
@@ -239,29 +248,7 @@
       </q-card>
     </q-dialog>
 
-    <q-dialog v-model="cheatSheetDialog">
-      <q-card style="min-width: 360px; max-width: 520px">
-        <q-card-section class="row items-center">
-          <q-icon name="menu_book" color="primary" size="36px" class="q-mr-md" />
-          <div>
-            <div class="text-h6">Onboarding cheat sheet</div>
-            <div class="text-subtitle2 text-grey-7">Quick reference for getting started</div>
-          </div>
-        </q-card-section>
-        <q-separator inset />
-        <q-card-section>
-          <ol class="q-pl-md">
-            <li class="q-mb-sm">Add your first environment to describe where applications deploy.</li>
-            <li class="q-mb-sm">Connect a data store so services can reference shared infrastructure.</li>
-            <li class="q-mb-sm">Create an application and link it to environments and data stores.</li>
-            <li>Review application details to track deployments and external dependencies.</li>
-          </ol>
-        </q-card-section>
-        <q-card-actions align="right">
-          <q-btn flat label="Close" color="primary" @click="cheatSheetDialog = false" />
-        </q-card-actions>
-      </q-card>
-    </q-dialog>
+    <CheatSheetDialog v-model="cheatSheetDialog" />
   </q-layout>
 </template>
 
@@ -279,6 +266,7 @@ import { useOnboardingTour } from './composables/useOnboardingTour'
 import { useEnvironments } from './composables/useEnvironments'
 import { useDataStores } from './composables/useDataStores'
 import { useApplications } from './composables/useApplications'
+import CheatSheetDialog from './components/onboarding/CheatSheetDialog.vue'
 
 const leftDrawerOpen = ref(true)
 const fuseStore = useFuseStore()

--- a/UI/Fuse.Web/src/components/onboarding/CheatSheetDialog.vue
+++ b/UI/Fuse.Web/src/components/onboarding/CheatSheetDialog.vue
@@ -1,0 +1,115 @@
+<template>
+  <q-dialog v-model="dialogVisible">
+    <q-card class="cheat-sheet-card">
+      <q-card-section class="row items-center">
+        <q-icon name="menu_book" color="primary" size="36px" class="q-mr-md" />
+        <div>
+          <div class="text-h6">Onboarding cheat sheet</div>
+          <div class="text-subtitle2 text-grey-7">
+            Quick reference for the key areas of Fuse Inventory
+          </div>
+        </div>
+        <q-space />
+        <q-btn flat dense round icon="close" @click="dialogVisible = false" />
+      </q-card-section>
+      <q-separator />
+      <q-card-section class="q-pt-none">
+        <q-list bordered separator>
+          <q-item
+            v-for="section in sections"
+            :key="section.title"
+            clickable
+            v-ripple
+            tag="router-link"
+            :to="section.to"
+          >
+            <q-item-section avatar>
+              <q-icon :name="section.icon" color="primary" />
+            </q-item-section>
+            <q-item-section>
+              <q-item-label class="text-subtitle1">{{ section.title }}</q-item-label>
+              <q-item-label caption>{{ section.description }}</q-item-label>
+            </q-item-section>
+            <q-item-section side>
+              <q-icon name="chevron_right" color="primary" />
+            </q-item-section>
+          </q-item>
+        </q-list>
+      </q-card-section>
+      <q-card-actions align="right">
+        <q-btn flat label="Close" color="primary" @click="dialogVisible = false" />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { RouteLocationRaw } from 'vue-router'
+
+const props = defineProps<{
+  modelValue: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+}>()
+
+const dialogVisible = computed({
+  get: () => props.modelValue,
+  set: (value: boolean) => emit('update:modelValue', value)
+})
+
+interface CheatSheetSection {
+  title: string
+  description: string
+  to: RouteLocationRaw
+  icon: string
+}
+
+const sections: CheatSheetSection[] = [
+  {
+    title: 'Home',
+    description: 'Review getting-started tips and the latest activity overview.',
+    to: { name: 'home' },
+    icon: 'home'
+  },
+  {
+    title: 'Environments',
+    description: 'Describe deployment targets and group related resources together.',
+    to: { name: 'environments' },
+    icon: 'cloud'
+  },
+  {
+    title: 'Data Stores',
+    description: 'Catalog databases and messaging backends to keep dependencies visible.',
+    to: { name: 'dataStores' },
+    icon: 'storage'
+  },
+  {
+    title: 'Applications & Instances',
+    description: 'Manage application metadata and map deployments to environments.',
+    to: { name: 'applications' },
+    icon: 'apps'
+  },
+  {
+    title: 'Accounts',
+    description: 'Track service accounts and credentials used across your stack.',
+    to: { name: 'accounts' },
+    icon: 'vpn_key'
+  },
+  {
+    title: 'Security',
+    description: 'Configure authentication and review access policies.',
+    to: { name: 'security' },
+    icon: 'security'
+  }
+]
+</script>
+
+<style scoped>
+.cheat-sheet-card {
+  min-width: 360px;
+  max-width: 520px;
+}
+</style>

--- a/UI/Fuse.Web/src/composables/useOnboardingTour.ts
+++ b/UI/Fuse.Web/src/composables/useOnboardingTour.ts
@@ -40,6 +40,7 @@ async function navigateToStep(index: number, initial = false): Promise<void> {
 
   if (index >= activeSteps.length) {
     onboardingStoreRef?.markCompleted()
+    onboardingStoreRef?.openCheatSheet()
     return
   }
 
@@ -173,7 +174,7 @@ export function useOnboardingTour() {
       stepsToRun.push({
         id: 'environments',
         route: '/environments',
-        selector: '[data-tour-id="environments"]',
+        selector: '[data-tour-id="create-environment"]',
         popover: {
           title: 'Add your first environment',
           description: 'Environments describe the deployment targets for your applications.'
@@ -185,7 +186,7 @@ export function useOnboardingTour() {
       stepsToRun.push({
         id: 'data-stores',
         route: '/data-stores',
-        selector: '[data-tour-id="data-stores"]',
+        selector: '[data-tour-id="create-data-store"]',
         popover: {
           title: 'Connect a data store',
           description: 'Data stores link applications to the infrastructure and services they depend on.'
@@ -197,7 +198,7 @@ export function useOnboardingTour() {
       stepsToRun.push({
         id: 'applications',
         route: '/applications',
-        selector: '[data-tour-id="applications"]',
+        selector: '[data-tour-id="create-application"]',
         popover: {
           title: 'Create your first application',
           description: 'Applications track deployments, pipelines, and the environments they target.'
@@ -227,6 +228,7 @@ export function useOnboardingTour() {
     if (!hasSteps) {
       driver.setSteps([])
       onboardingStore.markCompleted()
+      onboardingStore.openCheatSheet()
       return false
     }
 

--- a/UI/Fuse.Web/src/pages/ApplicationEditPage.vue
+++ b/UI/Fuse.Web/src/pages/ApplicationEditPage.vue
@@ -22,7 +22,7 @@
       @submit="handleSubmitApplication"
     />
 
-    <q-card class="content-card q-mb-md">
+    <q-card class="content-card q-mb-md" data-tour-id="application-detail">
       <q-card-section class="dialog-header">
         <div>
           <div class="text-h6">Application Instances</div>
@@ -30,7 +30,14 @@
             Track deployments across environments and hosts.
           </div>
         </div>
-        <q-btn color="primary" label="Add Instance" dense icon="add" @click="openInstanceDialog()" />
+        <q-btn
+          color="primary"
+          label="Add Instance"
+          dense
+          icon="add"
+          @click="openInstanceDialog()"
+          data-tour-id="add-instance"
+        />
       </q-card-section>
       <q-separator />
       <q-table
@@ -40,6 +47,7 @@
         :rows="application?.instances ?? []"
         :columns="instanceColumns"
         row-key="id"
+        data-tour-id="application-instances-table"
       >
         <template #body-cell-environment="props">
           <q-td :props="props">

--- a/UI/Fuse.Web/src/pages/ApplicationsPage.vue
+++ b/UI/Fuse.Web/src/pages/ApplicationsPage.vue
@@ -5,7 +5,13 @@
         <h1>Applications</h1>
         <p class="subtitle">Manage applications, deployments, and delivery pipelines.</p>
       </div>
-      <q-btn color="primary" label="Create Application" icon="add" @click="openCreateDialog" />
+      <q-btn
+        color="primary"
+        label="Create Application"
+        icon="add"
+        @click="openCreateDialog"
+        data-tour-id="create-application"
+      />
     </div>
 
     <q-banner v-if="applicationsError" dense class="bg-red-1 text-negative q-mb-md">
@@ -21,6 +27,7 @@
         row-key="id"
         :loading="applicationsLoading"
         :pagination="pagination"
+        data-tour-id="applications-table"
       >
         <template #body-cell-tags="props">
           <q-td :props="props">

--- a/UI/Fuse.Web/src/pages/DataStoresPage.vue
+++ b/UI/Fuse.Web/src/pages/DataStoresPage.vue
@@ -5,7 +5,13 @@
         <h1>Data Stores</h1>
         <p class="subtitle">Capture connection details for databases and messaging backends.</p>
       </div>
-      <q-btn color="primary" label="Create Data Store" icon="add" @click="openCreateDialog" />
+      <q-btn
+        color="primary"
+        label="Create Data Store"
+        icon="add"
+        @click="openCreateDialog"
+        data-tour-id="create-data-store"
+      />
     </div>
 
     <q-banner v-if="dataStoreError" dense class="bg-red-1 text-negative q-mb-md">
@@ -21,6 +27,7 @@
         row-key="id"
         :loading="isLoading"
         :pagination="pagination"
+        data-tour-id="data-stores-table"
       >
         <template #body-cell-environment="props">
           <q-td :props="props">

--- a/UI/Fuse.Web/src/pages/EnvironmentsPage.vue
+++ b/UI/Fuse.Web/src/pages/EnvironmentsPage.vue
@@ -5,7 +5,13 @@
         <h1>Environments</h1>
         <p class="subtitle">Model environments and attach resources to them.</p>
       </div>
-      <q-btn color="primary" label="Create Environment" icon="add" @click="openCreateDialog" />
+      <q-btn
+        color="primary"
+        label="Create Environment"
+        icon="add"
+        @click="openCreateDialog"
+        data-tour-id="create-environment"
+      />
     </div>
 
     <q-banner v-if="environmentError" dense class="bg-red-1 text-negative q-mb-md">
@@ -21,6 +27,7 @@
         row-key="id"
         :loading="isLoading"
         :pagination="pagination"
+        data-tour-id="environments-table"
       >
         <template #body-cell-tags="props">
           <q-td :props="props">

--- a/UI/Fuse.Web/src/stores/OnboardingStore.ts
+++ b/UI/Fuse.Web/src/stores/OnboardingStore.ts
@@ -92,6 +92,10 @@ export const useOnboardingStore = defineStore('onboarding', {
       this.showCheatSheet = visible
       persistState(this.$state)
     },
+    openCheatSheet() {
+      this.showCheatSheet = true
+      persistState(this.$state)
+    },
     setTourActive(active: boolean) {
       this.isTourActive = active
       persistState(this.$state)


### PR DESCRIPTION
## Summary
- add data-tour anchors to navigation links, resource tables, and create buttons used by the onboarding tour
- create a reusable onboarding cheat sheet dialog and surface it from the main layout
- update the tour flow to open the cheat sheet after completion and align selectors with the new anchors

## Testing
- npm run build *(fails: Rollup could not resolve driver.js/dist/driver.css; existing configuration likely needs to externalize the stylesheet)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f5ff7efe08333901bbb86d1663fef)