### PR TITLE
Refactor config export/import service to be simpler and more direct

### DIFF
--- a/API/Fuse.Core/Areas/Config/ConfigService.cs
+++ b/API/Fuse.Core/Areas/Config/ConfigService.cs
@@ -1,6 +1,8 @@
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Fuse.Core.Areas.Audit;
+using Fuse.Core.Helpers;
 using Fuse.Core.Interfaces;
 using Fuse.Core.Models;
 using Fuse.Core.Services;
@@ -25,6 +27,8 @@ public enum ConfigFormat
 public class ConfigService : IConfigService
 {
     private readonly IFuseStore _store;
+    private readonly IAuditService _auditService;
+    private readonly ICurrentUser _currentUser;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -45,9 +49,11 @@ public class ConfigService : IConfigService
         .WithObjectFactory(new RecordFriendlyObjectFactory())
         .Build();
 
-    public ConfigService(IFuseStore store)
+    public ConfigService(IFuseStore store, IAuditService auditService, ICurrentUser currentUser)
     {
         _store = store;
+        _auditService = auditService;
+        _currentUser = currentUser;
     }
 
     public async Task<string> ExportAsync(ConfigFormat format, CancellationToken ct = default)
@@ -72,6 +78,18 @@ public class ConfigService : IConfigService
             ConfigFormat.Yaml => YamlSerializer.Serialize(config),
             _ => throw new ArgumentException($"Unsupported format: {format}")
         };
+
+        await _auditService.LogAsync(AuditHelper.CreateLog(
+            AuditAction.ConfigExported,
+            AuditArea.Config,
+            _currentUser.UserName,
+            _currentUser.UserId,
+            null,
+            new
+            {
+                Format = format.ToString(),
+                ItemCount = config.Applications.Count + config.DataStores.Count + config.Platforms.Count
+            }), ct);
 
         return result;
     }
@@ -193,6 +211,11 @@ public class ConfigService : IConfigService
             throw new InvalidOperationException($"Failed to parse {format} content: {ex.Message}", ex);
         }
 
+        if (_store is IBackupCapableFuseStore backupCapableStore)
+        {
+            await backupCapableStore.CreateBackupAsync(ct);
+        }
+
         await _store.UpdateAsync(current =>
         {
             // Create lookup dictionaries for existing data
@@ -273,9 +296,26 @@ public class ConfigService : IConfigService
                 SecurityContext: current.SecurityContext,
                 AppSettings: current.AppSettings,
                 PasswordGeneratorConfig: current.PasswordGeneratorConfig,
-                AzureIntegrationManager: current.AzureIntegrationManager
+                AzureIntegrationManager: current.AzureIntegrationManager,
+                License: current.License
             );
         }, ct);
+
+        await _auditService.LogAsync(AuditHelper.CreateLog(
+            AuditAction.ConfigImported,
+            AuditArea.Config,
+            _currentUser.UserName,
+            _currentUser.UserId,
+            null,
+            new
+            {
+                Format = format.ToString(),
+                ApplicationCount = imported.Applications.Count,
+                DataStoreCount = imported.DataStores.Count,
+                PlatformCount = imported.Platforms.Count,
+                AccountCount = imported.Accounts.Count,
+                KumaIntegrationCount = imported.KumaIntegrations.Count
+            }), ct);
     }
 
     public class ConfigSnapshot

--- a/API/Fuse.Core/Areas/Config/ConfigService.cs
+++ b/API/Fuse.Core/Areas/Config/ConfigService.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Fuse.Core.Interfaces;
 using Fuse.Core.Models;
 using Fuse.Core.Services;
@@ -244,6 +245,11 @@ public class ConfigService : IConfigService
             foreach (var env in imported.Environments)
             {
                 existingEnvironments[env.Id] = env;
+            }
+
+            foreach (var kumaIntegration in imported.KumaIntegrations)
+            {
+                existingKumaIntegrations[kumaIntegration.Id] = kumaIntegration;
             }
 
             return new Snapshot(

--- a/API/Fuse.Core/Areas/Config/ConfigService.cs
+++ b/API/Fuse.Core/Areas/Config/ConfigService.cs
@@ -1,10 +1,8 @@
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using Fuse.Core.Helpers;
 using Fuse.Core.Interfaces;
 using Fuse.Core.Models;
-using Fuse.Core.Areas.Audit;
+using Fuse.Core.Services;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -26,8 +24,6 @@ public enum ConfigFormat
 public class ConfigService : IConfigService
 {
     private readonly IFuseStore _store;
-    private readonly IAuditService _auditService;
-    private readonly ICurrentUser _currentUser;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -48,11 +44,9 @@ public class ConfigService : IConfigService
         .WithObjectFactory(new RecordFriendlyObjectFactory())
         .Build();
 
-    public ConfigService(IFuseStore store, IAuditService auditService, ICurrentUser currentUser)
+    public ConfigService(IFuseStore store)
     {
         _store = store;
-        _auditService = auditService;
-        _currentUser = currentUser;
     }
 
     public async Task<string> ExportAsync(ConfigFormat format, CancellationToken ct = default)
@@ -77,18 +71,7 @@ public class ConfigService : IConfigService
             ConfigFormat.Yaml => YamlSerializer.Serialize(config),
             _ => throw new ArgumentException($"Unsupported format: {format}")
         };
-        
-        // Audit log
-        var auditLog = AuditHelper.CreateLog(
-            AuditAction.ConfigExported,
-            AuditArea.Config,
-            _currentUser.UserName,
-            _currentUser.UserId,
-            null,
-            new { Format = format.ToString(), ItemCount = config.Applications.Count + config.DataStores.Count + config.Platforms.Count }
-        );
-        await _auditService.LogAsync(auditLog, ct);
-        
+
         return result;
     }
 
@@ -287,89 +270,71 @@ public class ConfigService : IConfigService
                 AzureIntegrationManager: current.AzureIntegrationManager
             );
         }, ct);
-        
-        // Audit log
-        var auditLog = AuditHelper.CreateLog(
-            AuditAction.ConfigImported,
-            AuditArea.Config,
-            "System",
-            null,
-            null,
-            new 
-            { 
-                Format = format.ToString(), 
-                ApplicationCount = imported.Applications.Count,
-                DataStoreCount = imported.DataStores.Count,
-                PlatformCount = imported.Platforms.Count,
-                AccountCount = imported.Accounts.Count
-            }
-        );
-        await _auditService.LogAsync(auditLog, ct);
     }
-}
 
-public class ConfigSnapshot
-{
-    public List<Models.Application> Applications { get; set; } = new();
-    public List<Models.DataStore> DataStores { get; set; } = new();
-    public List<Models.Platform> Platforms { get; set; } = new();
-    public List<Models.ExternalResource> ExternalResources { get; set; } = new();
-    public List<Models.Account> Accounts { get; set; } = new();
-    public List<Models.Identity> Identities { get; set; } = new();
-    public List<Models.Tag> Tags { get; set; } = new();
-    public List<EnvironmentInfo> Environments { get; set; } = new();
-    public List<Models.KumaIntegration> KumaIntegrations { get; set; } = new();
-}
-
-internal class RecordFriendlyObjectFactory : YamlDotNet.Serialization.ObjectFactories.DefaultObjectFactory
-{
-    public override object Create(Type type)
+    public class ConfigSnapshot
     {
-        // For records, find a constructor and create with default values
-        if (type.IsClass || type.IsValueType)
+        public List<Models.Application> Applications { get; set; } = new();
+        public List<Models.DataStore> DataStores { get; set; } = new();
+        public List<Models.Platform> Platforms { get; set; } = new();
+        public List<Models.ExternalResource> ExternalResources { get; set; } = new();
+        public List<Models.Account> Accounts { get; set; } = new();
+        public List<Models.Identity> Identities { get; set; } = new();
+        public List<Models.Tag> Tags { get; set; } = new();
+        public List<EnvironmentInfo> Environments { get; set; } = new();
+        public List<Models.KumaIntegration> KumaIntegrations { get; set; } = new();
+    }
+
+    internal class RecordFriendlyObjectFactory : YamlDotNet.Serialization.ObjectFactories.DefaultObjectFactory
+    {
+        public override object Create(Type type)
         {
-            var constructors = type.GetConstructors();
-            if (constructors.Length > 0)
+            // For records, find a constructor and create with default values
+            if (type.IsClass || type.IsValueType)
             {
-                var ctor = constructors.OrderBy(c => c.GetParameters().Length).First();
-                var parameters = ctor.GetParameters();
-                var args = parameters.Select(p => GetDefaultValue(p.ParameterType)).ToArray();
-                
-                try
+                var constructors = type.GetConstructors();
+                if (constructors.Length > 0)
                 {
-                    return ctor.Invoke(args);
-                }
-                catch
-                {
-                    // Fall back to default behavior
+                    var ctor = constructors.OrderBy(c => c.GetParameters().Length).First();
+                    var parameters = ctor.GetParameters();
+                    var args = parameters.Select(p => GetDefaultValue(p.ParameterType)).ToArray();
+                    
+                    try
+                    {
+                        return ctor.Invoke(args);
+                    }
+                    catch
+                    {
+                        // Fall back to default behavior
+                    }
                 }
             }
+            
+            return base.Create(type);
         }
-        
-        return base.Create(type);
-    }
 
-    private static object? GetDefaultValue(Type type)
-    {
-        if (type == typeof(string))
-            return string.Empty;
-        if (type == typeof(Guid))
-            return Guid.Empty;
-        if (type == typeof(DateTime))
-            return DateTime.MinValue;
-        if (type == typeof(Uri))
+        private static object? GetDefaultValue(Type type)
+        {
+            if (type == typeof(string))
+                return string.Empty;
+            if (type == typeof(Guid))
+                return Guid.Empty;
+            if (type == typeof(DateTime))
+                return DateTime.MinValue;
+            if (type == typeof(Uri))
+                return null;
+            if (type.IsValueType)
+                return Activator.CreateInstance(type);
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(HashSet<>))
+            {
+                return Activator.CreateInstance(type);
+            }
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
+            {
+                var listType = typeof(List<>).MakeGenericType(type.GetGenericArguments());
+                return Activator.CreateInstance(listType);
+            }
             return null;
-        if (type.IsValueType)
-            return Activator.CreateInstance(type);
-        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(HashSet<>))
-        {
-            return Activator.CreateInstance(type);
         }
-        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
-        {
-            var listType = typeof(List<>).MakeGenericType(type.GetGenericArguments());
-            return Activator.CreateInstance(listType);
-        }
-        return null;
     }
 }

--- a/API/Fuse.Core/FuseCodeModule.cs
+++ b/API/Fuse.Core/FuseCodeModule.cs
@@ -22,7 +22,6 @@ using Fuse.Core.Areas.SecretProvider;
 using Fuse.Core.Areas.SqlIntegration;
 using Fuse.Core.Areas.Tag;
 using Fuse.Core.Areas.Undo;
-using Fuse.Core.Configs;
 using Fuse.Core.Interfaces;
 using Fuse.Core.Services;
 using Fuse.Core.Services.Startup;

--- a/API/Fuse.Core/FuseCodeModule.cs
+++ b/API/Fuse.Core/FuseCodeModule.cs
@@ -22,6 +22,7 @@ using Fuse.Core.Areas.SecretProvider;
 using Fuse.Core.Areas.SqlIntegration;
 using Fuse.Core.Areas.Tag;
 using Fuse.Core.Areas.Undo;
+using Fuse.Core.Configs;
 using Fuse.Core.Interfaces;
 using Fuse.Core.Services;
 using Fuse.Core.Services.Startup;

--- a/API/Fuse.Core/Interfaces/IFuseStore.cs
+++ b/API/Fuse.Core/Interfaces/IFuseStore.cs
@@ -12,3 +12,11 @@ public interface IFuseStore
     Snapshot? Current { get; }               // null until first load
     event Action<Snapshot>? Changed;         // fire after successful save
 }
+
+/// <summary>
+/// Implemented by persistent stores that can create a recovery point before a bulk update.
+/// </summary>
+public interface IBackupCapableFuseStore
+{
+    Task CreateBackupAsync(CancellationToken ct = default);
+}

--- a/API/Fuse.Data/Stores/JsonFuseStore.cs
+++ b/API/Fuse.Data/Stores/JsonFuseStore.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.IO.Compression;
 using Fuse.Core.Configs;
 using Fuse.Core.Helpers;
 using Fuse.Core.Interfaces;
@@ -7,7 +8,7 @@ using Fuse.Core.Models;
 
 namespace Fuse.Data.Stores;
 
-public sealed class JsonFuseStore : IFuseStore, IDisposable
+public sealed class JsonFuseStore : IFuseStore, IBackupCapableFuseStore, IDisposable
 {
     private readonly JsonFuseStoreOptions _options;
     private readonly SemaphoreSlim _mutex = new(1, 1);
@@ -152,6 +153,55 @@ public sealed class JsonFuseStore : IFuseStore, IDisposable
         var current = _cache ?? await LoadAsync(ct);
         var next = mutate(current);
         await SaveAsync(next, ct);
+    }
+
+    public async Task CreateBackupAsync(CancellationToken ct = default)
+    {
+        await _mutex.WaitAsync(ct);
+        try
+        {
+            var backupPath = Path.Combine(_options.DataDirectory, "fuse-data.bak");
+            var temporaryPath = backupPath + ".tmp";
+
+            try
+            {
+                await using (var stream = new FileStream(
+                    temporaryPath,
+                    FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.None,
+                    bufferSize: 81920,
+                    useAsync: true))
+                using (var archive = new ZipArchive(stream, ZipArchiveMode.Create))
+                {
+                    foreach (var path in Directory.EnumerateFiles(_options.DataDirectory, "*.json"))
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        var entry = archive.CreateEntry(Path.GetFileName(path), CompressionLevel.Optimal);
+                        await using var source = new FileStream(
+                            path,
+                            FileMode.Open,
+                            FileAccess.Read,
+                            FileShare.Read,
+                            bufferSize: 81920,
+                            useAsync: true);
+                        await using var destination = entry.Open();
+                        await source.CopyToAsync(destination, ct);
+                    }
+                }
+
+                File.Move(temporaryPath, backupPath, overwrite: true);
+            }
+            catch
+            {
+                File.Delete(temporaryPath);
+                throw;
+            }
+        }
+        finally
+        {
+            _mutex.Release();
+        }
     }
 
     private async Task<IReadOnlyList<T>> ReadAsync<T>(string file, CancellationToken ct)

--- a/API/Fuse.Tests/Services/ConfigServiceTests.cs
+++ b/API/Fuse.Tests/Services/ConfigServiceTests.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using Fuse.Core.Areas.Config;
+using Fuse.Core.Areas.Audit;
+using Fuse.Core.Interfaces;
 using Fuse.Core.Models;
 using Fuse.Tests.Helpers;
 using Fuse.Tests.TestInfrastructure;
@@ -9,6 +11,9 @@ namespace Fuse.Tests.Services;
 
 public class ConfigServiceTests
 {
+    private static ConfigService CreateService(IFuseStore store, FakeAuditService? audit = null) =>
+        new(store, audit ?? new FakeAuditService(), new FakeCurrentUser());
+
     private static InMemoryFuseStore NewStoreWith(
         Application[]? applications = null,
         DataStore[]? dataStores = null,
@@ -63,7 +68,7 @@ public class ConfigServiceTests
         );
         
         var store = NewStoreWith(applications: new[] { app });
-        var service = new ConfigService(store);
+        var service = CreateService(store);
 
         var result = await service.ExportAsync(ConfigFormat.Json);
 
@@ -75,13 +80,25 @@ public class ConfigServiceTests
     }
 
     [Fact]
+    public async Task ExportAsync_RecordsAuditEvent()
+    {
+        var audit = new FakeAuditService();
+        var service = CreateService(NewStoreWith(), audit);
+
+        await service.ExportAsync(ConfigFormat.Json);
+
+        var log = Assert.Single(audit.Logs);
+        Assert.Equal(AuditAction.ConfigExported, log.Action);
+    }
+
+    [Fact]
     public async Task ExportAsync_Yaml_ReturnsValidYaml()
     {
         var tag = new Tag(Guid.NewGuid(), "Production", "Production environment", TagColor.Red);
         
         var store = NewStoreWith(tags: new[] { tag });
 
-        var service = new ConfigService(store);
+        var service = CreateService(store);
 
         var result = await service.ExportAsync(ConfigFormat.Yaml);
 
@@ -94,7 +111,7 @@ public class ConfigServiceTests
     public async Task GetTemplateAsync_Json_ReturnsTemplate()
     {
         var store = NewStoreWith();
-        var service = new ConfigService(store);
+        var service = CreateService(store);
 
         var result = await service.GetTemplateAsync(ConfigFormat.Json);
 
@@ -109,7 +126,7 @@ public class ConfigServiceTests
     public async Task GetTemplateAsync_Yaml_ReturnsTemplate()
     {
         var store = NewStoreWith();
-        var service = new ConfigService(store);
+        var service = CreateService(store);
 
         var result = await service.GetTemplateAsync(ConfigFormat.Yaml);
 
@@ -121,7 +138,7 @@ public class ConfigServiceTests
     public async Task ImportAsync_Json_AddsNewItems()
     {
         var store = NewStoreWith();
-        var service = new ConfigService(store);
+        var service = CreateService(store);
 
         var newAppId = Guid.NewGuid();
         var importJson = $$"""
@@ -150,6 +167,18 @@ public class ConfigServiceTests
     }
 
     [Fact]
+    public async Task ImportAsync_RecordsAuditEvent()
+    {
+        var audit = new FakeAuditService();
+        var service = CreateService(NewStoreWith(), audit);
+
+        await service.ImportAsync("{}", ConfigFormat.Json);
+
+        var log = Assert.Single(audit.Logs);
+        Assert.Equal(AuditAction.ConfigImported, log.Action);
+    }
+
+    [Fact]
     public async Task ImportAsync_Json_UpdatesExistingItems()
     {
         var appId = Guid.NewGuid();
@@ -171,7 +200,7 @@ public class ConfigServiceTests
             );
 
         var store = NewStoreWith(applications: new[] { existingApp });
-        var service = new ConfigService(store);
+        var service = CreateService(store);
 
         var importJson = $$"""
             {
@@ -238,7 +267,7 @@ public class ConfigServiceTests
             );
 
         var store = NewStoreWith(applications: new[] { app1, app2 });
-        var service = new ConfigService(store);
+        var service = CreateService(store);
 
         var importJson = $$"""
             {
@@ -269,7 +298,7 @@ public class ConfigServiceTests
     public async Task ImportAsync_Yaml_Works()
     {
         var store = NewStoreWith();
-        var service = new ConfigService(store);
+        var service = CreateService(store);
 
         var tagId = Guid.NewGuid();
         var importYaml = $@"
@@ -293,7 +322,7 @@ tags:
     public async Task ImportAsync_InvalidJson_ThrowsException()
     {
         var store = NewStoreWith();
-        var service = new ConfigService(store);
+        var service = CreateService(store);
 
         var invalidJson = "{ invalid json }";
 
@@ -305,7 +334,7 @@ tags:
     public async Task ImportAsync_PartialImport_Works()
     {
         var store = NewStoreWith();
-        var service = new ConfigService(store);
+        var service = CreateService(store);
 
         var envId = Guid.NewGuid();
         var importJson = $$"""
@@ -334,7 +363,7 @@ tags:
     public async Task ImportAsync_Json_AddsKumaIntegrations()
     {
         var store = NewStoreWith();
-        var service = new ConfigService(store);
+        var service = CreateService(store);
 
         var kumaId = Guid.NewGuid();
         var importJson = $$"""

--- a/API/Fuse.Tests/Services/ConfigServiceTests.cs
+++ b/API/Fuse.Tests/Services/ConfigServiceTests.cs
@@ -1,6 +1,7 @@
 using Fuse.Core.Models;
 using Fuse.Core.Services;
 using Fuse.Tests.TestInfrastructure;
+using System.IO;
 using System.Linq;
 using Xunit;
 using System.Text.Json;
@@ -37,6 +38,78 @@ public class ConfigServiceTests
         return new InMemoryFuseStore(snapshot);
     }
 
+    private async Task WriteSnapshotToDirectoryAsync(InMemoryFuseStore store, string dataDirectory, CancellationToken ct = default)
+    {
+        var snapshot = await store.GetAsync(ct);
+        
+        // Applications
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "applications.json"), 
+            JsonSerializer.Serialize(snapshot.Applications, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // DataStores
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "datastores.json"), 
+            JsonSerializer.Serialize(snapshot.DataStores, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // Platforms
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "platforms.json"), 
+            JsonSerializer.Serialize(snapshot.Platforms, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // ExternalResources
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "externalresources.json"), 
+            JsonSerializer.Serialize(snapshot.ExternalResources, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // Accounts
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "accounts.json"), 
+            JsonSerializer.Serialize(snapshot.Accounts, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // Identities
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "identities.json"), 
+            JsonSerializer.Serialize(snapshot.Identities, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // Tags
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "tags.json"), 
+            JsonSerializer.Serialize(snapshot.Tags, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // Environments
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "environments.json"), 
+            JsonSerializer.Serialize(snapshot.Environments, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // KumaIntegrations
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "kumaintegrations.json"), 
+            JsonSerializer.Serialize(snapshot.KumaIntegrations, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // SecretProviders
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "secretproviders.json"), 
+            JsonSerializer.Serialize(snapshot.SecretProviders, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // SqlIntegrations
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "sqlintegrations.json"), 
+            JsonSerializer.Serialize(snapshot.SqlIntegrations, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // Positions
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "positions.json"), 
+            JsonSerializer.Serialize(snapshot.Positions, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // ResponsibilityTypes
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "responsibilitytypes.json"), 
+            JsonSerializer.Serialize(snapshot.ResponsibilityTypes, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // ResponsibilityAssignments
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "responsibilityassignments.json"), 
+            JsonSerializer.Serialize(snapshot.ResponsibilityAssignments, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // Risks
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "risks.json"), 
+            JsonSerializer.Serialize(snapshot.Risks, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // MessageBrokers
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "messagebrokers.json"), 
+            JsonSerializer.Serialize(snapshot.MessageBrokers, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // Security
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "security.json"), 
+            JsonSerializer.Serialize(snapshot.Security, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // SecurityContext
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "securitycontext.json"), 
+            JsonSerializer.Serialize(snapshot.SecurityContext, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // AppSettings
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "appsettings.json"), 
+            JsonSerializer.Serialize(snapshot.AppSettings, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // PasswordGeneratorConfig
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "passwordgeneratorconfig.json"), 
+            JsonSerializer.Serialize(snapshot.PasswordGeneratorConfig, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // AzureIntegrationManager
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "azureintegrationmanager.json"), 
+            JsonSerializer.Serialize(snapshot.AzureIntegrationManager, new JsonSerializerOptions { WriteIndented = true }), ct);
+        // License
+        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "license.json"), 
+            JsonSerializer.Serialize(snapshot.License, new JsonSerializerOptions { WriteIndented = true }), ct);
+    }
+
     [Fact]
     public async Task ExportAsync_Json_ReturnsValidJson()
     {
@@ -56,20 +129,35 @@ public class ConfigServiceTests
             DateTime.UtcNow,
             DateTime.UtcNow
         );
+            DateTime.UtcNow
+        );
 
         var store = NewStoreWith(applications: new[] { app });
-        var service = new ConfigService(store, new FakeAuditService(), new FakeCurrentUser());
 
-        var result = await service.ExportAsync(ConfigFormat.Json);
+        // Create a temporary directory and write the store data to it
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            await WriteSnapshotToDirectoryAsync(store, tempDir);
 
-    Assert.False(string.IsNullOrEmpty(result));
-        
-        // Verify it's valid JSON
-    var parsed = JsonDocument.Parse(result);
-    Assert.NotNull(parsed);
-        
-        // Verify it contains our application
-    Assert.Contains("TestApp", result);
+            var service = new ConfigService(tempDir);
+
+            var result = await service.ExportAsync(ConfigFormat.Json);
+
+            Assert.False(string.IsNullOrEmpty(result));
+            
+            // Verify it's valid JSON
+            var parsed = JsonDocument.Parse(result);
+            Assert.NotNull(parsed);
+            
+            // Verify it contains our application
+            Assert.Contains("TestApp", result);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
@@ -78,200 +166,280 @@ public class ConfigServiceTests
         var tag = new Tag(Guid.NewGuid(), "Production", "Production environment", TagColor.Red);
         
         var store = NewStoreWith(tags: new[] { tag });
-        var service = new ConfigService(store, new FakeAuditService(), new FakeCurrentUser());
 
-        var result = await service.ExportAsync(ConfigFormat.Yaml);
+        // Create a temporary directory and write the store data to it
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            await WriteSnapshotToDirectoryAsync(store, tempDir);
 
-    Assert.False(string.IsNullOrEmpty(result));
-    Assert.Contains("Production", result);
-    Assert.Contains("tags:", result);
+            var service = new ConfigService(tempDir);
+
+            var result = await service.ExportAsync(ConfigFormat.Yaml);
+
+            Assert.False(string.IsNullOrEmpty(result));
+            Assert.Contains("Production", result);
+            Assert.Contains("tags:", result);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
     public async Task GetTemplateAsync_Json_ReturnsTemplate()
     {
-        var store = NewStoreWith();
-        var service = new ConfigService(store, new FakeAuditService(), new FakeCurrentUser());
+        // Create a temporary directory (empty)
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var store = NewStoreWith();
+            var service = new ConfigService(tempDir);
 
-        var result = await service.GetTemplateAsync(ConfigFormat.Json);
+            var result = await service.GetTemplateAsync(ConfigFormat.Json);
 
-    Assert.False(string.IsNullOrEmpty(result));
-    Assert.Contains("Example", result);
-        
-        // Verify it's valid JSON
-    var parsed2 = JsonDocument.Parse(result);
-    Assert.NotNull(parsed2);
+            Assert.False(string.IsNullOrEmpty(result));
+            Assert.Contains("Example", result);
+            
+            // Verify it's valid JSON
+            var parsed2 = JsonDocument.Parse(result);
+            Assert.NotNull(parsed2);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
     public async Task GetTemplateAsync_Yaml_ReturnsTemplate()
     {
-        var store = NewStoreWith();
-        var service = new ConfigService(store, new FakeAuditService(), new FakeCurrentUser());
+        // Create a temporary directory (empty)
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var store = NewStoreWith();
+            var service = new ConfigService(tempDir);
 
-        var result = await service.GetTemplateAsync(ConfigFormat.Yaml);
+            var result = await service.GetTemplateAsync(ConfigFormat.Yaml);
 
-    Assert.False(string.IsNullOrEmpty(result));
-    Assert.Contains("Example", result);
+            Assert.False(string.IsNullOrEmpty(result));
+            Assert.Contains("Example", result);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
     public async Task ImportAsync_Json_AddsNewItems()
     {
-        var store = NewStoreWith();
-        var service = new ConfigService(store, new FakeAuditService(), new FakeCurrentUser());
-
-        var newAppId = Guid.NewGuid();
-        var importJson = $$"""
+        // Create a temporary directory
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        try
         {
-            "applications": [
-                {
-                    "id": "{{newAppId}}",
-                    "name": "ImportedApp",
-                    "version": "1.0",
-                    "tagIds": [],
-                    "instances": [],
-                    "pipelines": [],
-                    "createdAt": "2024-01-01T00:00:00Z",
-                    "updatedAt": "2024-01-01T00:00:00Z"
-                }
-            ]
+            var store = NewStoreWith();
+            var service = new ConfigService(tempDir);
+
+            var newAppId = Guid.NewGuid();
+            var importJson = $$"""
+            {
+                "applications": [
+                    {
+                        "id": "{{newAppId}}",
+                        "name": "ImportedApp",
+                        "version": "1.0",
+                        "tagIds": [],
+                        "instances": [],
+                        "pipelines": [],
+                        "createdAt": "2024-01-01T00:00:00Z",
+                        "updatedAt": "2024-01-01T00:00:00Z"
+                    }
+                ]
+            }
+            """;
+
+            await service.ImportAsync(importJson, ConfigFormat.Json);
+
+            // Verify the file was written
+            var filePath = Path.Combine(tempDir, "applications.json");
+            Assert.True(File.Exists(filePath));
+            var content = await File.ReadAllTextAsync(filePath);
+            Assert.Contains("ImportedApp", content);
+            Assert.Contains(newAppId.ToString(), content);
         }
-        """;
-
-        await service.ImportAsync(importJson, ConfigFormat.Json);
-
-        var snapshot = await store.GetAsync();
-    Assert.Single(snapshot.Applications);
-    Assert.Equal("ImportedApp", snapshot.Applications[0].Name);
-    Assert.Equal(newAppId, snapshot.Applications[0].Id);
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
     public async Task ImportAsync_Json_UpdatesExistingItems()
     {
-        var appId = Guid.NewGuid();
-        var existingApp = new Application(
-            appId,
-            "OldName",
-            "1.0",
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            new HashSet<Guid>(),
-            Array.Empty<ApplicationInstance>(),
-            Array.Empty<ApplicationPipeline>(),
-            DateTime.UtcNow,
-            DateTime.UtcNow
-        );
-
-        var store = NewStoreWith(applications: new[] { existingApp });
-        var service = new ConfigService(store, new FakeAuditService(), new FakeCurrentUser());
-
-        var importJson = $$"""
+        // Create a temporary directory
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        try
         {
-            "applications": [
-                {
-                    "id": "{{appId}}",
-                    "name": "UpdatedName",
-                    "version": "2.0",
-                    "tagIds": [],
-                    "instances": [],
-                    "pipelines": [],
-                    "createdAt": "2024-01-01T00:00:00Z",
-                    "updatedAt": "2024-01-01T00:00:00Z"
-                }
-            ]
+            var appId = Guid.NewGuid();
+            var existingApp = new Application(
+                appId,
+                "OldName",
+                "1.0",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                new HashSet<Guid>(),
+                Array.Empty<ApplicationInstance>(),
+                Array.Empty<ApplicationPipeline>(),
+                DateTime.UtcNow,
+                DateTime.UtcNow
+            );
+
+            var store = NewStoreWith(applications: new[] { existingApp });
+            // Write the initial data to the temp directory
+            await WriteSnapshotToDirectoryAsync(store, tempDir);
+
+            var service = new ConfigService(tempDir);
+
+            var importJson = $$"""
+            {
+                "applications": [
+                    {
+                        "id": "{{appId}}",
+                        "name": "UpdatedName",
+                        "version": "2.0",
+                        "tagIds": [],
+                        "instances": [],
+                        "pipelines": [],
+                        "createdAt": "2024-01-01T00:00:00Z",
+                        "updatedAt": "2024-01-01T00:00:00Z"
+                    }
+                ]
+            }
+            """;
+
+            await service.ImportAsync(importJson, ConfigFormat.Json);
+
+            // Verify the file was updated
+            var filePath = Path.Combine(tempDir, "applications.json");
+            Assert.True(File.Exists(filePath));
+            var content = await File.ReadAllTextAsync(filePath);
+            Assert.Contains("UpdatedName", content);
+            Assert.Contains("2.0", content);
+            Assert.Contains(appId.ToString(), content);
         }
-        """;
-
-        await service.ImportAsync(importJson, ConfigFormat.Json);
-
-        var snapshot = await store.GetAsync();
-    Assert.Single(snapshot.Applications);
-    Assert.Equal("UpdatedName", snapshot.Applications[0].Name);
-    Assert.Equal("2.0", snapshot.Applications[0].Version);
-    Assert.Equal(appId, snapshot.Applications[0].Id);
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
     public async Task ImportAsync_Json_PreservesUnmentionedItems()
     {
-        var app1Id = Guid.NewGuid();
-        var app2Id = Guid.NewGuid();
-        var app1 = new Application(
-            app1Id,
-            "App1",
-            "1.0",
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            new HashSet<Guid>(),
-            Array.Empty<ApplicationInstance>(),
-            Array.Empty<ApplicationPipeline>(),
-            DateTime.UtcNow,
-            DateTime.UtcNow
-        );
-        var app2 = new Application(
-            app2Id,
-            "App2",
-            "1.0",
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            new HashSet<Guid>(),
-            Array.Empty<ApplicationInstance>(),
-            Array.Empty<ApplicationPipeline>(),
-            DateTime.UtcNow,
-            DateTime.UtcNow
-        );
-
-        var store = NewStoreWith(applications: new[] { app1, app2 });
-        var service = new ConfigService(store, new FakeAuditService(), new FakeCurrentUser());
-
-        // Import only updates app1, should preserve app2
-        var importJson = $$"""
+        // Create a temporary directory
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        try
         {
-            "applications": [
-                {
-                    "id": "{{app1Id}}",
-                    "name": "UpdatedApp1",
-                    "version": "2.0",
-                    "tagIds": [],
-                    "instances": [],
-                    "pipelines": [],
-                    "createdAt": "2024-01-01T00:00:00Z",
-                    "updatedAt": "2024-01-01T00:00:00Z"
-                }
-            ]
+            var app1Id = Guid.NewGuid();
+            var app2Id = Guid.NewGuid();
+            var app1 = new Application(
+                app1Id,
+                "App1",
+                "1.0",
+                null,
+                null,
+                null,
+                null,
+                null,
+                new HashSet<Guid>(),
+                Array.Empty<ApplicationInstance>(),
+                Array.Empty<ApplicationPipeline>(),
+                DateTime.UtcNow,
+                DateTime.UtcNow
+            );
+            var app2 = new Application(
+                app2Id,
+                "App2",
+                "1.0",
+                null,
+                null,
+                null,
+                null,
+                null,
+                new HashSet<Guid>(),
+                Array.Empty<ApplicationInstance>(),
+                Array.Empty<ApplicationPipeline>(),
+                DateTime.UtcNow,
+                DateTime.UtcNow
+            );
+
+            var store = NewStoreWith(applications: new[] { app1, app2 });
+            // Write the initial data to the temp directory
+            await WriteSnapshotToDirectoryAsync(store, tempDir);
+
+            var service = new ConfigService(tempDir);
+
+            // Import only updates app1, should preserve app2
+            var importJson = $$"""
+            {
+                "applications": [
+                    {
+                        "id": "{{app1Id}}",
+                        "name": "UpdatedApp1",
+                        "version": "2.0",
+                        "tagIds": [],
+                        "instances": [],
+                        "pipelines": [],
+                        "createdAt": "2024-01-01T00:00:00Z",
+                        "updatedAt": "2024-01-01T00:00:00Z"
+                    }
+                ]
+            }
+            """;
+
+            await service.ImportAsync(importJson, ConfigFormat.Json);
+
+            // Verify the file contains both apps
+            var filePath = Path.Combine(tempDir, "applications.json");
+            Assert.True(File.Exists(filePath));
+            var content = await File.ReadAllTextAsync(filePath);
+            Assert.Contains("UpdatedApp1", content);
+            Assert.Contains("App2", content);
+            Assert.Contains(app1Id.ToString(), content);
+            Assert.Contains(app2Id.ToString(), content);
         }
-        """;
-
-        await service.ImportAsync(importJson, ConfigFormat.Json);
-
-        var snapshot = await store.GetAsync();
-    Assert.Equal(2, snapshot.Applications.Count);
-    Assert.Contains(snapshot.Applications, a => a.Id == app1Id && a.Name == "UpdatedApp1");
-    Assert.Contains(snapshot.Applications, a => a.Id == app2Id && a.Name == "App2");
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
     public async Task ImportAsync_Yaml_Works()
     {
-        var store = NewStoreWith();
-        var service = new ConfigService(store, new FakeAuditService(), new FakeCurrentUser());
+        // Create a temporary directory
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var store = NewStoreWith();
+            var service = new ConfigService(tempDir);
 
-        var tagId = Guid.NewGuid();
-        var importYaml = $@"
+            var tagId = Guid.NewGuid();
+            var importYaml = $@"
 tags:
   - id: {tagId}
     name: ImportedTag
@@ -279,52 +447,86 @@ tags:
     color: Blue
 ";
 
-        await service.ImportAsync(importYaml, ConfigFormat.Yaml);
+            await service.ImportAsync(importYaml, ConfigFormat.Yaml);
 
-        var snapshot = await store.GetAsync();
-    Assert.Single(snapshot.Tags);
-    Assert.Equal("ImportedTag", snapshot.Tags[0].Name);
-    Assert.Equal(TagColor.Blue, snapshot.Tags[0].Color);
+            // Verify the file was written
+            var filePath = Path.Combine(tempDir, "tags.json");
+            Assert.True(File.Exists(filePath));
+            var content = await File.ReadAllTextAsync(filePath);
+            Assert.Contains("ImportedTag", content);
+            Assert.Contains("Blue", content);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
     public async Task ImportAsync_InvalidJson_ThrowsException()
     {
-        var store = NewStoreWith();
-        var service = new ConfigService(store, new FakeAuditService(), new FakeCurrentUser());
+        // Create a temporary directory
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var store = NewStoreWith();
+            var service = new ConfigService(tempDir);
 
-        var invalidJson = "{ invalid json }";
+            var invalidJson = "{ invalid json }";
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.ImportAsync(invalidJson, ConfigFormat.Json));
-        Assert.Contains("Failed to parse", ex.Message);
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.ImportAsync(invalidJson, ConfigFormat.Json));
+            Assert.Contains("Failed to parse", ex.Message);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
     public async Task ImportAsync_PartialImport_Works()
     {
-        var store = NewStoreWith();
-        var service = new ConfigService(store, new FakeAuditService(), new FakeCurrentUser());
-
-        // Import only environments, no applications
-        var envId = Guid.NewGuid();
-        var importJson = $$"""
+        // Create a temporary directory
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        try
         {
-            "environments": [
-                {
-                    "id": "{{envId}}",
-                    "name": "Production",
-                    "description": "Production environment",
-                    "tagIds": []
-                }
-            ]
+            var store = NewStoreWith();
+            var service = new ConfigService(tempDir);
+
+            // Import only environments, no applications
+            var envId = Guid.NewGuid();
+            var importJson = $$"""
+            {
+                "environments": [
+                    {
+                        "id": "{{envId}}",
+                        "name": "Production",
+                        "description": "Production environment",
+                        "tagIds": []
+                    }
+                ]
+            }
+            """;
+
+            await service.ImportAsync(importJson, ConfigFormat.Json);
+
+            // Verify the environments file was written and applications file is empty array
+            var envFilePath = Path.Combine(tempDir, "environments.json");
+            Assert.True(File.Exists(envFilePath));
+            var envContent = await File.ReadAllTextAsync(envFilePath);
+            Assert.Contains("Production", envContent);
+            Assert.Contains(envId.ToString(), envContent);
+
+            var appFilePath = Path.Combine(tempDir, "applications.json");
+            Assert.True(File.Exists(appFilePath));
+            var appContent = await File.ReadAllTextAsync(appFilePath);
+            Assert.Equal("[]", appContent); // Should be an empty array
         }
-        """;
-
-        await service.ImportAsync(importJson, ConfigFormat.Json);
-
-        var snapshot = await store.GetAsync();
-    Assert.Single(snapshot.Environments);
-    Assert.Equal("Production", snapshot.Environments[0].Name);
-    Assert.Empty(snapshot.Applications);
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 }

--- a/API/Fuse.Tests/Services/ConfigServiceTests.cs
+++ b/API/Fuse.Tests/Services/ConfigServiceTests.cs
@@ -1,11 +1,9 @@
-using Fuse.Core.Models;
-using Fuse.Core.Services;
-using Fuse.Tests.TestInfrastructure;
-using System.IO;
-using System.Linq;
-using Xunit;
 using System.Text.Json;
+using Fuse.Core.Areas.Config;
+using Fuse.Core.Models;
 using Fuse.Tests.Helpers;
+using Fuse.Tests.TestInfrastructure;
+using Xunit;
 
 namespace Fuse.Tests.Services;
 
@@ -30,84 +28,18 @@ public class ConfigServiceTests
             Tags: tags ?? Array.Empty<Tag>(),
             Environments: environments ?? Array.Empty<EnvironmentInfo>(),
             KumaIntegrations: Array.Empty<KumaIntegration>(),
-                SecretProviders: Array.Empty<SecretProvider>(),
-                SqlIntegrations: Array.Empty<SqlIntegration>(), Positions: Array.Empty<Position>(), ResponsibilityTypes: Array.Empty<ResponsibilityType>(), ResponsibilityAssignments: Array.Empty<ResponsibilityAssignment>(),
-                Security: new SecurityState(new SecuritySettings(SecurityLevel.None, DateTime.UtcNow), Array.Empty<SecurityUser>()),
-                SecurityContextHelper.Get
+            SecretProviders: Array.Empty<SecretProvider>(),
+            SqlIntegrations: Array.Empty<SqlIntegration>(),
+            Positions: Array.Empty<Position>(),
+            ResponsibilityTypes: Array.Empty<ResponsibilityType>(),
+            ResponsibilityAssignments: Array.Empty<ResponsibilityAssignment>(),
+            Risks: Array.Empty<Risk>(),
+            MessageBrokers: Array.Empty<MessageBroker>(),
+            Security: new SecurityState(new SecuritySettings(SecurityLevel.None, DateTime.UtcNow), Array.Empty<SecurityUser>()),
+            SecurityContextHelper.Get,
+            new AppSettings()
         );
         return new InMemoryFuseStore(snapshot);
-    }
-
-    private async Task WriteSnapshotToDirectoryAsync(InMemoryFuseStore store, string dataDirectory, CancellationToken ct = default)
-    {
-        var snapshot = await store.GetAsync(ct);
-        
-        // Applications
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "applications.json"), 
-            JsonSerializer.Serialize(snapshot.Applications, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // DataStores
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "datastores.json"), 
-            JsonSerializer.Serialize(snapshot.DataStores, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // Platforms
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "platforms.json"), 
-            JsonSerializer.Serialize(snapshot.Platforms, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // ExternalResources
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "externalresources.json"), 
-            JsonSerializer.Serialize(snapshot.ExternalResources, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // Accounts
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "accounts.json"), 
-            JsonSerializer.Serialize(snapshot.Accounts, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // Identities
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "identities.json"), 
-            JsonSerializer.Serialize(snapshot.Identities, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // Tags
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "tags.json"), 
-            JsonSerializer.Serialize(snapshot.Tags, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // Environments
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "environments.json"), 
-            JsonSerializer.Serialize(snapshot.Environments, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // KumaIntegrations
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "kumaintegrations.json"), 
-            JsonSerializer.Serialize(snapshot.KumaIntegrations, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // SecretProviders
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "secretproviders.json"), 
-            JsonSerializer.Serialize(snapshot.SecretProviders, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // SqlIntegrations
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "sqlintegrations.json"), 
-            JsonSerializer.Serialize(snapshot.SqlIntegrations, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // Positions
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "positions.json"), 
-            JsonSerializer.Serialize(snapshot.Positions, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // ResponsibilityTypes
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "responsibilitytypes.json"), 
-            JsonSerializer.Serialize(snapshot.ResponsibilityTypes, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // ResponsibilityAssignments
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "responsibilityassignments.json"), 
-            JsonSerializer.Serialize(snapshot.ResponsibilityAssignments, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // Risks
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "risks.json"), 
-            JsonSerializer.Serialize(snapshot.Risks, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // MessageBrokers
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "messagebrokers.json"), 
-            JsonSerializer.Serialize(snapshot.MessageBrokers, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // Security
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "security.json"), 
-            JsonSerializer.Serialize(snapshot.Security, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // SecurityContext
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "securitycontext.json"), 
-            JsonSerializer.Serialize(snapshot.SecurityContext, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // AppSettings
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "appsettings.json"), 
-            JsonSerializer.Serialize(snapshot.AppSettings, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // PasswordGeneratorConfig
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "passwordgeneratorconfig.json"), 
-            JsonSerializer.Serialize(snapshot.PasswordGeneratorConfig, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // AzureIntegrationManager
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "azureintegrationmanager.json"), 
-            JsonSerializer.Serialize(snapshot.AzureIntegrationManager, new JsonSerializerOptions { WriteIndented = true }), ct);
-        // License
-        await File.WriteAllTextAsync(Path.Combine(dataDirectory, "license.json"), 
-            JsonSerializer.Serialize(snapshot.License, new JsonSerializerOptions { WriteIndented = true }), ct);
     }
 
     [Fact]
@@ -129,35 +61,17 @@ public class ConfigServiceTests
             DateTime.UtcNow,
             DateTime.UtcNow
         );
-            DateTime.UtcNow
-        );
-
+        
         var store = NewStoreWith(applications: new[] { app });
+        var service = new ConfigService(store);
 
-        // Create a temporary directory and write the store data to it
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(tempDir);
-        try
-        {
-            await WriteSnapshotToDirectoryAsync(store, tempDir);
+        var result = await service.ExportAsync(ConfigFormat.Json);
 
-            var service = new ConfigService(tempDir);
-
-            var result = await service.ExportAsync(ConfigFormat.Json);
-
-            Assert.False(string.IsNullOrEmpty(result));
-            
-            // Verify it's valid JSON
-            var parsed = JsonDocument.Parse(result);
-            Assert.NotNull(parsed);
-            
-            // Verify it contains our application
-            Assert.Contains("TestApp", result);
-        }
-        finally
-        {
-            Directory.Delete(tempDir, recursive: true);
-        }
+        Assert.False(string.IsNullOrEmpty(result));
+        var parsed = JsonDocument.Parse(result);
+        Assert.True(parsed.RootElement.TryGetProperty("applications", out var applications));
+        Assert.Contains("TestApp", result);
+        Assert.Equal(1, applications.GetArrayLength());
     }
 
     [Fact]
@@ -167,88 +81,50 @@ public class ConfigServiceTests
         
         var store = NewStoreWith(tags: new[] { tag });
 
-        // Create a temporary directory and write the store data to it
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(tempDir);
-        try
-        {
-            await WriteSnapshotToDirectoryAsync(store, tempDir);
+        var service = new ConfigService(store);
 
-            var service = new ConfigService(tempDir);
+        var result = await service.ExportAsync(ConfigFormat.Yaml);
 
-            var result = await service.ExportAsync(ConfigFormat.Yaml);
-
-            Assert.False(string.IsNullOrEmpty(result));
-            Assert.Contains("Production", result);
-            Assert.Contains("tags:", result);
-        }
-        finally
-        {
-            Directory.Delete(tempDir, recursive: true);
-        }
+        Assert.False(string.IsNullOrEmpty(result));
+        Assert.Contains("Production", result);
+        Assert.Contains("tags:", result);
     }
 
     [Fact]
     public async Task GetTemplateAsync_Json_ReturnsTemplate()
     {
-        // Create a temporary directory (empty)
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(tempDir);
-        try
-        {
-            var store = NewStoreWith();
-            var service = new ConfigService(tempDir);
+        var store = NewStoreWith();
+        var service = new ConfigService(store);
 
-            var result = await service.GetTemplateAsync(ConfigFormat.Json);
+        var result = await service.GetTemplateAsync(ConfigFormat.Json);
 
-            Assert.False(string.IsNullOrEmpty(result));
-            Assert.Contains("Example", result);
-            
-            // Verify it's valid JSON
-            var parsed2 = JsonDocument.Parse(result);
-            Assert.NotNull(parsed2);
-        }
-        finally
-        {
-            Directory.Delete(tempDir, recursive: true);
-        }
+        Assert.False(string.IsNullOrEmpty(result));
+        Assert.Contains("Example", result);
+
+        var parsed = JsonDocument.Parse(result);
+        Assert.True(parsed.RootElement.TryGetProperty("applications", out _));
     }
 
     [Fact]
     public async Task GetTemplateAsync_Yaml_ReturnsTemplate()
     {
-        // Create a temporary directory (empty)
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(tempDir);
-        try
-        {
-            var store = NewStoreWith();
-            var service = new ConfigService(tempDir);
+        var store = NewStoreWith();
+        var service = new ConfigService(store);
 
-            var result = await service.GetTemplateAsync(ConfigFormat.Yaml);
+        var result = await service.GetTemplateAsync(ConfigFormat.Yaml);
 
-            Assert.False(string.IsNullOrEmpty(result));
-            Assert.Contains("Example", result);
-        }
-        finally
-        {
-            Directory.Delete(tempDir, recursive: true);
-        }
+        Assert.False(string.IsNullOrEmpty(result));
+        Assert.Contains("Example", result);
     }
 
     [Fact]
     public async Task ImportAsync_Json_AddsNewItems()
     {
-        // Create a temporary directory
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(tempDir);
-        try
-        {
-            var store = NewStoreWith();
-            var service = new ConfigService(tempDir);
+        var store = NewStoreWith();
+        var service = new ConfigService(store);
 
-            var newAppId = Guid.NewGuid();
-            var importJson = $$"""
+        var newAppId = Guid.NewGuid();
+        var importJson = $$"""
             {
                 "applications": [
                     {
@@ -265,31 +141,19 @@ public class ConfigServiceTests
             }
             """;
 
-            await service.ImportAsync(importJson, ConfigFormat.Json);
+        await service.ImportAsync(importJson, ConfigFormat.Json);
 
-            // Verify the file was written
-            var filePath = Path.Combine(tempDir, "applications.json");
-            Assert.True(File.Exists(filePath));
-            var content = await File.ReadAllTextAsync(filePath);
-            Assert.Contains("ImportedApp", content);
-            Assert.Contains(newAppId.ToString(), content);
-        }
-        finally
-        {
-            Directory.Delete(tempDir, recursive: true);
-        }
+        var snapshot = await store.GetAsync();
+        var app = Assert.Single(snapshot.Applications);
+        Assert.Equal(newAppId, app.Id);
+        Assert.Equal("ImportedApp", app.Name);
     }
 
     [Fact]
     public async Task ImportAsync_Json_UpdatesExistingItems()
     {
-        // Create a temporary directory
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(tempDir);
-        try
-        {
-            var appId = Guid.NewGuid();
-            var existingApp = new Application(
+        var appId = Guid.NewGuid();
+        var existingApp = new Application(
                 appId,
                 "OldName",
                 "1.0",
@@ -306,13 +170,10 @@ public class ConfigServiceTests
                 DateTime.UtcNow
             );
 
-            var store = NewStoreWith(applications: new[] { existingApp });
-            // Write the initial data to the temp directory
-            await WriteSnapshotToDirectoryAsync(store, tempDir);
+        var store = NewStoreWith(applications: new[] { existingApp });
+        var service = new ConfigService(store);
 
-            var service = new ConfigService(tempDir);
-
-            var importJson = $$"""
+        var importJson = $$"""
             {
                 "applications": [
                     {
@@ -329,33 +190,21 @@ public class ConfigServiceTests
             }
             """;
 
-            await service.ImportAsync(importJson, ConfigFormat.Json);
+        await service.ImportAsync(importJson, ConfigFormat.Json);
 
-            // Verify the file was updated
-            var filePath = Path.Combine(tempDir, "applications.json");
-            Assert.True(File.Exists(filePath));
-            var content = await File.ReadAllTextAsync(filePath);
-            Assert.Contains("UpdatedName", content);
-            Assert.Contains("2.0", content);
-            Assert.Contains(appId.ToString(), content);
-        }
-        finally
-        {
-            Directory.Delete(tempDir, recursive: true);
-        }
+        var snapshot = await store.GetAsync();
+        var app = Assert.Single(snapshot.Applications);
+        Assert.Equal(appId, app.Id);
+        Assert.Equal("UpdatedName", app.Name);
+        Assert.Equal("2.0", app.Version);
     }
 
     [Fact]
     public async Task ImportAsync_Json_PreservesUnmentionedItems()
     {
-        // Create a temporary directory
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(tempDir);
-        try
-        {
-            var app1Id = Guid.NewGuid();
-            var app2Id = Guid.NewGuid();
-            var app1 = new Application(
+        var app1Id = Guid.NewGuid();
+        var app2Id = Guid.NewGuid();
+        var app1 = new Application(
                 app1Id,
                 "App1",
                 "1.0",
@@ -364,13 +213,14 @@ public class ConfigServiceTests
                 null,
                 null,
                 null,
+                null,
                 new HashSet<Guid>(),
                 Array.Empty<ApplicationInstance>(),
                 Array.Empty<ApplicationPipeline>(),
                 DateTime.UtcNow,
                 DateTime.UtcNow
             );
-            var app2 = new Application(
+        var app2 = new Application(
                 app2Id,
                 "App2",
                 "1.0",
@@ -379,6 +229,7 @@ public class ConfigServiceTests
                 null,
                 null,
                 null,
+                null,
                 new HashSet<Guid>(),
                 Array.Empty<ApplicationInstance>(),
                 Array.Empty<ApplicationPipeline>(),
@@ -386,14 +237,10 @@ public class ConfigServiceTests
                 DateTime.UtcNow
             );
 
-            var store = NewStoreWith(applications: new[] { app1, app2 });
-            // Write the initial data to the temp directory
-            await WriteSnapshotToDirectoryAsync(store, tempDir);
+        var store = NewStoreWith(applications: new[] { app1, app2 });
+        var service = new ConfigService(store);
 
-            var service = new ConfigService(tempDir);
-
-            // Import only updates app1, should preserve app2
-            var importJson = $$"""
+        var importJson = $$"""
             {
                 "applications": [
                     {
@@ -410,36 +257,22 @@ public class ConfigServiceTests
             }
             """;
 
-            await service.ImportAsync(importJson, ConfigFormat.Json);
+        await service.ImportAsync(importJson, ConfigFormat.Json);
 
-            // Verify the file contains both apps
-            var filePath = Path.Combine(tempDir, "applications.json");
-            Assert.True(File.Exists(filePath));
-            var content = await File.ReadAllTextAsync(filePath);
-            Assert.Contains("UpdatedApp1", content);
-            Assert.Contains("App2", content);
-            Assert.Contains(app1Id.ToString(), content);
-            Assert.Contains(app2Id.ToString(), content);
-        }
-        finally
-        {
-            Directory.Delete(tempDir, recursive: true);
-        }
+        var snapshot = await store.GetAsync();
+        Assert.Equal(2, snapshot.Applications.Count);
+        Assert.Contains(snapshot.Applications, app => app.Id == app1Id && app.Name == "UpdatedApp1");
+        Assert.Contains(snapshot.Applications, app => app.Id == app2Id && app.Name == "App2");
     }
 
     [Fact]
     public async Task ImportAsync_Yaml_Works()
     {
-        // Create a temporary directory
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(tempDir);
-        try
-        {
-            var store = NewStoreWith();
-            var service = new ConfigService(tempDir);
+        var store = NewStoreWith();
+        var service = new ConfigService(store);
 
-            var tagId = Guid.NewGuid();
-            var importYaml = $@"
+        var tagId = Guid.NewGuid();
+        var importYaml = $@"
 tags:
   - id: {tagId}
     name: ImportedTag
@@ -447,57 +280,35 @@ tags:
     color: Blue
 ";
 
-            await service.ImportAsync(importYaml, ConfigFormat.Yaml);
+        await service.ImportAsync(importYaml, ConfigFormat.Yaml);
 
-            // Verify the file was written
-            var filePath = Path.Combine(tempDir, "tags.json");
-            Assert.True(File.Exists(filePath));
-            var content = await File.ReadAllTextAsync(filePath);
-            Assert.Contains("ImportedTag", content);
-            Assert.Contains("Blue", content);
-        }
-        finally
-        {
-            Directory.Delete(tempDir, recursive: true);
-        }
+        var snapshot = await store.GetAsync();
+        var tag = Assert.Single(snapshot.Tags);
+        Assert.Equal(tagId, tag.Id);
+        Assert.Equal("ImportedTag", tag.Name);
+        Assert.Equal(TagColor.Blue, tag.Color);
     }
 
     [Fact]
     public async Task ImportAsync_InvalidJson_ThrowsException()
     {
-        // Create a temporary directory
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(tempDir);
-        try
-        {
-            var store = NewStoreWith();
-            var service = new ConfigService(tempDir);
+        var store = NewStoreWith();
+        var service = new ConfigService(store);
 
-            var invalidJson = "{ invalid json }";
+        var invalidJson = "{ invalid json }";
 
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.ImportAsync(invalidJson, ConfigFormat.Json));
-            Assert.Contains("Failed to parse", ex.Message);
-        }
-        finally
-        {
-            Directory.Delete(tempDir, recursive: true);
-        }
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.ImportAsync(invalidJson, ConfigFormat.Json));
+        Assert.Contains("Failed to parse", ex.Message);
     }
 
     [Fact]
     public async Task ImportAsync_PartialImport_Works()
     {
-        // Create a temporary directory
-        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(tempDir);
-        try
-        {
-            var store = NewStoreWith();
-            var service = new ConfigService(tempDir);
+        var store = NewStoreWith();
+        var service = new ConfigService(store);
 
-            // Import only environments, no applications
-            var envId = Guid.NewGuid();
-            var importJson = $$"""
+        var envId = Guid.NewGuid();
+        var importJson = $$"""
             {
                 "environments": [
                     {
@@ -510,23 +321,45 @@ tags:
             }
             """;
 
-            await service.ImportAsync(importJson, ConfigFormat.Json);
+        await service.ImportAsync(importJson, ConfigFormat.Json);
 
-            // Verify the environments file was written and applications file is empty array
-            var envFilePath = Path.Combine(tempDir, "environments.json");
-            Assert.True(File.Exists(envFilePath));
-            var envContent = await File.ReadAllTextAsync(envFilePath);
-            Assert.Contains("Production", envContent);
-            Assert.Contains(envId.ToString(), envContent);
+        var snapshot = await store.GetAsync();
+        var environment = Assert.Single(snapshot.Environments);
+        Assert.Equal(envId, environment.Id);
+        Assert.Equal("Production", environment.Name);
+        Assert.Empty(snapshot.Applications);
+    }
 
-            var appFilePath = Path.Combine(tempDir, "applications.json");
-            Assert.True(File.Exists(appFilePath));
-            var appContent = await File.ReadAllTextAsync(appFilePath);
-            Assert.Equal("[]", appContent); // Should be an empty array
-        }
-        finally
+    [Fact]
+    public async Task ImportAsync_Json_AddsKumaIntegrations()
+    {
+        var store = NewStoreWith();
+        var service = new ConfigService(store);
+
+        var kumaId = Guid.NewGuid();
+        var importJson = $$"""
         {
-            Directory.Delete(tempDir, recursive: true);
+            "kumaIntegrations": [
+                {
+                    "id": "{{kumaId}}",
+                    "name": "Kuma Prod",
+                    "environmentIds": [],
+                    "platformId": null,
+                    "accountId": null,
+                    "uri": "https://kuma.example.com",
+                    "apiKey": "token",
+                    "createdAt": "2024-01-01T00:00:00Z",
+                    "updatedAt": "2024-01-01T00:00:00Z"
+                }
+            ]
         }
+        """;
+
+        await service.ImportAsync(importJson, ConfigFormat.Json);
+
+        var snapshot = await store.GetAsync();
+        var kuma = Assert.Single(snapshot.KumaIntegrations);
+        Assert.Equal(kumaId, kuma.Id);
+        Assert.Equal("Kuma Prod", kuma.Name);
     }
 }

--- a/API/Fuse.Tests/Stores/JsonFuseStoreTests.cs
+++ b/API/Fuse.Tests/Stores/JsonFuseStoreTests.cs
@@ -1,4 +1,5 @@
 using Fuse.Core.Configs;
+using System.IO.Compression;
 using Fuse.Core.Models;
 using Fuse.Data.Stores;
 using Fuse.Tests.Helpers;
@@ -22,6 +23,28 @@ public class JsonFuseStoreTests : IDisposable
         {
             Directory.Delete(_testDataDirectory, true);
         }
+    }
+
+    [Fact]
+    public async Task CreateBackupAsync_CreatesArchiveContainingCurrentDataFiles()
+    {
+        const string applicationsJson = "[{\"name\":\"before-import\"}]";
+        await File.WriteAllTextAsync(
+            Path.Combine(_testDataDirectory, "applications.json"),
+            applicationsJson);
+
+        using var store = new JsonFuseStore(
+            new JsonFuseStoreOptions { DataDirectory = _testDataDirectory });
+
+        await store.CreateBackupAsync();
+
+        var backupPath = Path.Combine(_testDataDirectory, "fuse-data.bak");
+        Assert.True(File.Exists(backupPath));
+        using var archive = ZipFile.OpenRead(backupPath);
+        var entry = Assert.Single(archive.Entries, entry => entry.FullName == "applications.json");
+        using var reader = new StreamReader(entry.Open());
+        Assert.Equal(applicationsJson, await reader.ReadToEndAsync());
+        Assert.False(File.Exists(backupPath + ".tmp"));
     }
 
     [Fact]

--- a/API/Fuse.Tests/TestInfrastructure/SqlServerFixture.cs
+++ b/API/Fuse.Tests/TestInfrastructure/SqlServerFixture.cs
@@ -1,6 +1,7 @@
 using Microsoft.Data.SqlClient;
-using Testcontainers.MsSql;
+using System.Runtime.InteropServices;
 using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
 using Xunit;
 using Xunit.Sdk;
 
@@ -13,10 +14,20 @@ public class SqlServerCollection : ICollectionFixture<SqlServerFixture>
 
 public class SqlServerFixture : IAsyncLifetime
 {
-    private readonly MsSqlContainer _container;
+    private readonly IContainer _container;
     private readonly bool _reuseContainer;
+    private readonly bool _isArm64;
+    private const int SqlPort = 1433;
+    private const string SqlPassword = "YourStrong@Passw0rd";
 
-    public string MasterConnectionString => _container.GetConnectionString();
+    public string MasterConnectionString
+    {
+        get
+        {
+            var port = _container.GetMappedPublicPort(SqlPort);
+            return $"Server={_container.Hostname},{port};Database=master;User ID=sa;Password={SqlPassword};Encrypt=False;TrustServerCertificate=True;Connection Timeout=30;";
+        }
+    }
 
     public SqlServerFixture()
     {
@@ -25,10 +36,18 @@ public class SqlServerFixture : IAsyncLifetime
             "true",
             StringComparison.OrdinalIgnoreCase);
 
-        var builder = new MsSqlBuilder()
-            .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
-            .WithPassword("YourStrong@Passw0rd")
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(1433));
+        _isArm64 = RuntimeInformation.ProcessArchitecture == Architecture.Arm64;
+
+        var sqlImage = _isArm64
+            ? "mcr.microsoft.com/azure-sql-edge:latest"
+            : "mcr.microsoft.com/mssql/server:2022-latest";
+
+        var builder = new ContainerBuilder()
+            .WithImage(sqlImage)
+            .WithPortBinding(SqlPort, assignRandomHostPort: true)
+            .WithEnvironment("ACCEPT_EULA", "Y")
+            .WithEnvironment("MSSQL_SA_PASSWORD", SqlPassword)
+            .WithEnvironment("MSSQL_PID", "Developer");
 
         if (_reuseContainer)
         {
@@ -47,20 +66,22 @@ public class SqlServerFixture : IAsyncLifetime
         var completed = await Task.WhenAny(startTask, Task.Delay(timeout));
         if (completed != startTask)
         {
-            string combined = string.Empty;
-            try
-            {
-                var (stdout, stderr) = await _container.GetLogsAsync();
-                combined = (stdout ?? string.Empty) + "\n" + (stderr ?? string.Empty);
-            }
-            catch { /* ignore */ }
-            var preview = combined.Length > 2000 ? combined.Substring(0, 2000) : combined;
+            var preview = await GetContainerLogsPreviewAsync();
             throw new XunitException($"SQL Server container did not start within {timeout.TotalSeconds} seconds. Ensure Docker is running and the image can be pulled. Try: docker pull mcr.microsoft.com/mssql/server:2022-latest\nContainer logs (truncated):\n{preview}");
         }
-        await startTask;
+
+        try
+        {
+            await startTask;
+        }
+        catch
+        {
+            var preview = await GetContainerLogsPreviewAsync();
+            throw new XunitException($"SQL container failed to start.\nContainer logs (truncated):\n{preview}");
+        }
 
         // Post-start readiness: poll until SQL accepts connections
-        var maxAttempts = 60;
+        var maxAttempts = _isArm64 ? 180 : 60;
         for (var i = 0; i < maxAttempts; i++)
         {
             try
@@ -75,10 +96,27 @@ public class SqlServerFixture : IAsyncLifetime
                 await Task.Delay(1000);
                 if (i == maxAttempts - 1)
                 {
-                    throw new XunitException("SQL Server did not accept connections within 60s after container start.");
+                    var preview = await GetContainerLogsPreviewAsync();
+                    throw new XunitException($"SQL Server did not accept connections within {maxAttempts}s after container start.\nContainer logs (truncated):\n{preview}");
                 }
             }
         }
+    }
+
+    private async Task<string> GetContainerLogsPreviewAsync()
+    {
+        string combined = string.Empty;
+        try
+        {
+            var (stdout, stderr) = await _container.GetLogsAsync();
+            combined = (stdout ?? string.Empty) + "\n" + (stderr ?? string.Empty);
+        }
+        catch
+        {
+            // Ignore log retrieval failures; startup error is enough context.
+        }
+
+        return combined.Length > 3000 ? combined.Substring(0, 3000) : combined;
     }
 
     public async Task DisposeAsync()


### PR DESCRIPTION
Simplified the config export to just use the Json available when exporting. When importing .bak files are used in the case of an issue