### PR TITLE
ci: add Docker layer caching for ARM builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,8 @@ jobs:
           GIT_COMMIT_ID=${{ steps.buildmeta.outputs.git_commit_id }}
           GIT_COMMIT_ID_SHORT=${{ steps.buildmeta.outputs.git_commit_id_short }}
           BUILD_DATE=${{ steps.buildmeta.outputs.build_date }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
   build-and-push-release-image:
     name: Build and Push Release Image
@@ -193,3 +195,5 @@ jobs:
           GIT_COMMIT_ID=${{ steps.buildmeta.outputs.git_commit_id }}
           GIT_COMMIT_ID_SHORT=${{ steps.buildmeta.outputs.git_commit_id_short }}
           BUILD_DATE=${{ steps.buildmeta.outputs.build_date }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max


### PR DESCRIPTION
## Problem

The CI pipeline takes 15+ minutes on every push to `main`. Both build jobs (`build-and-push-pre-release-image` and `build-and-push-release-image`) build multi-arch Docker images (amd64 + arm64) from **scratch every time** — no Docker layer caching is configured.

This means:
- Base images (`mcr.microsoft.com/dotnet/sdk:10.0`, `node:20-alpine`) are downloaded every build
- `npm ci` and `dotnet restore` run from scratch each time
- All of this runs through QEMU emulation for the arm64 target, magnifying the slowdown

## Fix

Add Docker BuildKit cache using GitHub Actions cache backend:

```yaml
cache-from: type=gha
cache-to: type=gha,mode=max
```

This is applied to both build jobs' `docker/build-push-action` steps.

## Expected Impact

- **First build** after this change: same speed (~15 min, cache fills up)
- **Subsequent builds**: ~3-5 min (cached base images and dependency layers reused, only changed source layers rebuild)

The arm64 build specifically benefits because QEMU-emulated layer execution only happens for changed layers, not the entire build.